### PR TITLE
Add HTTPS Support and Configuration for Elastic Beanstalk Environment

### DIFF
--- a/.ebextensions/https-single-instance.config
+++ b/.ebextensions/https-single-instance.config
@@ -1,0 +1,61 @@
+# Documentation: https://gist.github.com/the-vampiire/489299336200659a8f96cb6f2d593b64?permalink_comment_id=3242847
+# AWS resources to be provisioned for the EB environment
+Resources:
+  # Define a security group rule that allows HTTPS traffic to the EC2 instance
+  sslSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      # Add the rule to the Elastic Beanstalk environment's security group
+      GroupId: { "Fn::GetAtt": ["AWSEBSecurityGroup", "GroupId"] }
+      IpProtocol: tcp
+      # Allow inbound traffic on port 443 (HTTPS)
+      ToPort: 443
+      FromPort: 443
+      CidrIp: 0.0.0.0/0
+
+  # Ensure the EC2 instance has permissions to access the S3 bucket
+  AWSEBAutoScalingGroup:
+    Metadata:
+      AWS::CloudFormation::Authentication:
+        S3Auth:
+          type: "s3"
+          buckets: ["edukona-ssl-certs"]
+          roleName:
+            "Fn::GetOptionSetting":
+              Namespace: "aws:autoscaling:launchconfiguration"
+              OptionName: "IamInstanceProfile"
+              DefaultValue: "aws-elasticbeanstalk-ec2-role-custom"
+
+# Install necessary packages (e.g., mod_ssl for Apache, if needed)
+packages:
+  yum:
+    mod_ssl: []
+
+# Copy SSL certificate files from S3 to the EC2 instance
+files:
+  /var/log/ebextensions-debug.log:
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      Starting .ebextensions script execution...
+
+  /etc/letsencrypt/live/edukona.com/fullchain.pem:
+    mode: "000400"
+    owner: root
+    group: root
+    source: 'https://edukona-ssl-certs.s3.us-west-2.amazonaws.com/edukona.com-0002/fullchain.pem'
+    authentication: S3Auth
+
+  /etc/letsencrypt/live/edukona.com/privkey.pem:
+    mode: "000400"
+    owner: root
+    group: root
+    source: 'https://edukona-ssl-certs.s3.us-west-2.amazonaws.com/edukona.com-0002/privkey.pem'
+    authentication: S3Auth
+
+container_commands:
+  00_debug_log:
+    command: "echo '.ebextensions script running' >> /var/log/ebextensions-debug.log"
+  01_reload_nginx:
+    command: "service nginx reload >> /var/log/ebextensions-debug.log 2>&1"

--- a/.ebextensions/https-single-instance.config
+++ b/.ebextensions/https-single-instance.config
@@ -55,7 +55,8 @@ files:
     authentication: S3Auth
 
 container_commands:
-  00_debug_log:
-    command: "echo '.ebextensions script running' >> /var/log/ebextensions-debug.log"
-  01_reload_nginx:
-    command: "service nginx reload >> /var/log/ebextensions-debug.log 2>&1"
+  01_start_nginx:
+    command: "systemctl start nginx"
+
+  02_reload_nginx:
+    command: "systemctl reload nginx"

--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -1,6 +1,3 @@
-branch-defaults:
-  "*":
-    environment: hice-backend
 global:
   application_name: hice_backend
   branch: null

--- a/.platform/nginx/conf.d/https.conf
+++ b/.platform/nginx/conf.d/https.conf
@@ -1,0 +1,29 @@
+# Nginx Configuration
+upstream edukona {
+    server localhost:8080;
+}
+# HTTPS server
+server {
+    listen       443 ssl;
+    server_name  edukona.com *.edukona.com;
+    ssl_certificate      /etc/letsencrypt/live/edukona.com/fullchain.pem;
+    ssl_certificate_key  /etc/letsencrypt/live/edukona.com/privkey.pem;
+
+    ssl_session_timeout  5m;
+
+    ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers   on; 
+
+    access_log  /var/log/nginx/access-443.log  main;
+    error_log   /var/log/nginx/error-443.log   error;
+
+    location / {
+        proxy_pass       http://edukona;
+        proxy_set_header   Connection "";
+        proxy_http_version 1.1;
+        proxy_set_header        Host            $host;
+        proxy_set_header        X-Real-IP       $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto https;
+    }
+}

--- a/.platform/nginx/conf.d/https.conf
+++ b/.platform/nginx/conf.d/https.conf
@@ -1,6 +1,6 @@
 # Nginx Configuration
 upstream edukona {
-    server localhost:8080;
+    server localhost:8000;
 }
 # HTTPS server
 server {

--- a/.platform/nginx/conf.d/https.conf
+++ b/.platform/nginx/conf.d/https.conf
@@ -12,18 +12,30 @@ server {
     ssl_session_timeout  5m;
 
     ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
-    ssl_prefer_server_ciphers   on; 
+    ssl_prefer_server_ciphers   on;
 
     access_log  /var/log/nginx/access-443.log  main;
     error_log   /var/log/nginx/error-443.log   error;
 
+    # Main location for proxying HTTP requests to Django app
     location / {
         proxy_pass       http://edukona;
-        proxy_set_header   Connection "";
         proxy_http_version 1.1;
-        proxy_set_header        Host            $host;
-        proxy_set_header        X-Real-IP       $remote_addr;
-        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header        X-Forwarded-Proto https;
+        proxy_set_header Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    # WebSocket location for handling WebSocket connections
+    location /ws/ {
+        proxy_pass http://edukona;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
     }
 }

--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -1,0 +1,46 @@
+#Elastic Beanstalk Nginx Configuration File
+
+user                    nginx;
+error_log               /var/log/nginx/error.log warn;
+pid                     /var/run/nginx.pid;
+worker_processes        auto;
+worker_rlimit_nofile    200000;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server_tokens off;
+    
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    include       conf.d/*.conf;
+
+    map $http_upgrade $connection_upgrade {
+        default     "upgrade";
+    }
+
+    server {
+        listen        80 default_server;
+        access_log    /var/log/nginx/access.log main;
+
+        # redirect to https and maintain the requested URL
+        return 301 https://$host$request_uri;
+
+        client_header_timeout 60;
+        client_body_timeout   60;
+        keepalive_timeout     60;
+        gzip                  off;
+        gzip_comp_level       4;
+        gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+        # Include the Elastic Beanstalk generated locations
+        include conf.d/elasticbeanstalk/*.conf;
+    }
+}

--- a/ebsconfig.json
+++ b/ebsconfig.json
@@ -1,0 +1,17 @@
+[
+    {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "EnvironmentType",
+        "Value": "SingleInstance"
+    },
+    {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "IamInstanceProfile",
+        "Value": "aws-elasticbeanstalk-ec2-role"
+    },
+    {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType",
+        "Value": "t4g.micro"
+    }
+]


### PR DESCRIPTION
This PR introduces several key enhancements to support HTTPS for the Elastic Beanstalk environment. The following changes have been made:

- **New Configuration Files**:
  - Added `.ebextensions/https-single-instance.config` to configure HTTPS support and security settings.
  - Created `.platform/nginx/conf.d/https.conf` for Nginx HTTPS server configuration.
  - Introduced `.platform/nginx/nginx.conf` for the main Nginx configuration, including default server behavior.
  - Added `ebsconfig.json` to set instance profile and environment type.

- **Security Group Configuration**:
  - Configured a security group rule in `https-single-instance.config` to allow inbound HTTPS traffic on port 443 from all IP addresses.

- **Certificate Management**:
  - Included S3 authentication for accessing SSL certificate files stored in S3.
  - Specified the source locations for SSL certificates in the configuration file.

- **Nginx Configuration**:
  - Set up an upstream block for the application.
  - Configured SSL termination on port 443 with appropriate certificate paths.
  - Redirect HTTP traffic from port 80 to HTTPS, maintaining the requested URL.
  - Set up specific locations for handling regular HTTP requests and WebSocket connections.

- **Package Installation**:
  - Installed `mod_ssl` via Yum to enable SSL support for Nginx.

- **Logging**:
  - Defined separate access and error logs for both HTTP and HTTPS in the Nginx configuration.

- **Starting Nginx**:
  - Added container commands to start and reload Nginx when the environment is provisioned. 

These changes ensure that the application running on the Elastic Beanstalk environment is now accessible over HTTPS, enhancing security and user trust.