### PR TITLE
Create API to Delete Recordings (Restricted by User Ownership)

### DIFF
--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -36,16 +36,12 @@ class SignUpInstructor(APIView):
 
     def post(self, request):
         new_user = request.data.pop("user", {})
-        instructor = Instructor.objects.create(
-            user=User.objects.create(**new_user), **request.data
-        )
+        instructor = Instructor.objects.create(user=User.objects.create(**new_user), **request.data)
         user = get_object_or_404(User, id=instructor.user_id)
         user.set_password(new_user["password"])
         user.save()
         token = Token.objects.create(user=user)
-        return JsonResponse(
-            {"token": token.key, "user": user.id, "instructor": instructor.id}
-        )
+        return JsonResponse({"token": token.key, "user": user.id, "instructor": instructor.id})
 
 
 class LoginSerializer(serializers.Serializer):
@@ -73,14 +69,10 @@ class Login(APIView):
         try:
             user = User.objects.get(username=request.data["username"])
         except User.DoesNotExist:
-            return JsonResponse(
-                {"detail": "User Not Found!"}, status=status.HTTP_401_UNAUTHORIZED
-            )
+            return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_401_UNAUTHORIZED)
 
         if not user.check_password(request.data["password"]):
-            return JsonResponse(
-                {"detail": "User Not Found!"}, status=status.HTTP_400_BAD_REQUEST
-            )
+            return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_400_BAD_REQUEST)
         token = Token.objects.get_or_create(user=user)
         if hasattr(user, "instructor"):
             return JsonResponse(
@@ -176,13 +168,9 @@ class UserResponseView(APIView):
     def post(self, request):
         student_data = request.data.pop("student", {})
         student = get_object_or_404(QuizSessionStudent, id=student_data["id"])
-        question = get_object_or_404(
-            QuestionMultipleChoice, id=request.data["question_id"]
-        )
+        question = get_object_or_404(QuestionMultipleChoice, id=request.data["question_id"])
         selected_answer = request.data["selected_answer"]
-        quiz_session = get_object_or_404(
-            QuizSession, code=request.data["quiz_session_code"]
-        )
+        quiz_session = get_object_or_404(QuizSession, code=request.data["quiz_session_code"])
 
         is_correct = selected_answer == question.correct_answer
         new_user_response = UserResponse.objects.create(
@@ -214,9 +202,7 @@ class UserResponseView(APIView):
             UserResponse, id=response_id, student_id=request.data["student_id"]
         )
 
-        is_correct = (
-            request.data.get("selected_answer") == user_response.question.correct_answer
-        )
+        is_correct = request.data.get("selected_answer") == user_response.question.correct_answer
         user_response.__dict__.update({"is_correct": is_correct, **request.data})
         user_response.save()
 
@@ -299,9 +285,7 @@ class UploadAudioView(APIView):
                 ),
             )
 
-            return JsonResponse(
-                InstructorRecordingsSerializer(new_recording).data, status=201
-            )
+            return JsonResponse(InstructorRecordingsSerializer(new_recording).data, status=201)
 
         except Exception as e:
             transaction.set_rollback(True)
@@ -364,9 +348,9 @@ class RecordingsView(APIView):
     )
     def get(self, request):
         instructor = request.user.instructor
-        recordings = InstructorRecordings.objects.filter(
-            instructor=instructor
-        ).order_by("-uploaded_at")
+        recordings = InstructorRecordings.objects.filter(instructor=instructor).order_by(
+            "-uploaded_at"
+        )
 
         # Filter so that the serializer only returns the s3_path, uploaded_at, id
 

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -36,12 +36,16 @@ class SignUpInstructor(APIView):
 
     def post(self, request):
         new_user = request.data.pop("user", {})
-        instructor = Instructor.objects.create(user=User.objects.create(**new_user), **request.data)
+        instructor = Instructor.objects.create(
+            user=User.objects.create(**new_user), **request.data
+        )
         user = get_object_or_404(User, id=instructor.user_id)
         user.set_password(new_user["password"])
         user.save()
         token = Token.objects.create(user=user)
-        return JsonResponse({"token": token.key, "user": user.id, "instructor": instructor.id})
+        return JsonResponse(
+            {"token": token.key, "user": user.id, "instructor": instructor.id}
+        )
 
 
 class LoginSerializer(serializers.Serializer):
@@ -69,10 +73,14 @@ class Login(APIView):
         try:
             user = User.objects.get(username=request.data["username"])
         except User.DoesNotExist:
-            return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_401_UNAUTHORIZED)
+            return JsonResponse(
+                {"detail": "User Not Found!"}, status=status.HTTP_401_UNAUTHORIZED
+            )
 
         if not user.check_password(request.data["password"]):
-            return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_400_BAD_REQUEST)
+            return JsonResponse(
+                {"detail": "User Not Found!"}, status=status.HTTP_400_BAD_REQUEST
+            )
         token = Token.objects.get_or_create(user=user)
         if hasattr(user, "instructor"):
             return JsonResponse(
@@ -168,9 +176,13 @@ class UserResponseView(APIView):
     def post(self, request):
         student_data = request.data.pop("student", {})
         student = get_object_or_404(QuizSessionStudent, id=student_data["id"])
-        question = get_object_or_404(QuestionMultipleChoice, id=request.data["question_id"])
+        question = get_object_or_404(
+            QuestionMultipleChoice, id=request.data["question_id"]
+        )
         selected_answer = request.data["selected_answer"]
-        quiz_session = get_object_or_404(QuizSession, code=request.data["quiz_session_code"])
+        quiz_session = get_object_or_404(
+            QuizSession, code=request.data["quiz_session_code"]
+        )
 
         is_correct = selected_answer == question.correct_answer
         new_user_response = UserResponse.objects.create(
@@ -202,7 +214,9 @@ class UserResponseView(APIView):
             UserResponse, id=response_id, student_id=request.data["student_id"]
         )
 
-        is_correct = request.data.get("selected_answer") == user_response.question.correct_answer
+        is_correct = (
+            request.data.get("selected_answer") == user_response.question.correct_answer
+        )
         user_response.__dict__.update({"is_correct": is_correct, **request.data})
         user_response.save()
 
@@ -285,7 +299,9 @@ class UploadAudioView(APIView):
                 ),
             )
 
-            return JsonResponse(InstructorRecordingsSerializer(new_recording).data, status=201)
+            return JsonResponse(
+                InstructorRecordingsSerializer(new_recording).data, status=201
+            )
 
         except Exception as e:
             transaction.set_rollback(True)
@@ -348,9 +364,9 @@ class RecordingsView(APIView):
     )
     def get(self, request):
         instructor = request.user.instructor
-        recordings = InstructorRecordings.objects.filter(instructor=instructor).order_by(
-            "-uploaded_at"
-        )
+        recordings = InstructorRecordings.objects.filter(
+            instructor=instructor
+        ).order_by("-uploaded_at")
 
         # Filter so that the serializer only returns the s3_path, uploaded_at, id
 
@@ -374,6 +390,7 @@ class DeleteRecordingView(APIView):
         description="Deletes the recording with the specified id",
         responses={
             200: OpenApiTypes.OBJECT,
+            401: OpenApiTypes.OBJECT,
             404: OpenApiTypes.OBJECT,
             403: OpenApiTypes.OBJECT,
             500: OpenApiTypes.OBJECT,

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -113,6 +113,11 @@ urlpatterns = [
         name="update-transcript",
     ),
     path(
+        "instructor-recordings/<uuid:recording_id>/delete-recording",
+        DeleteRecordingView.as_view(),
+        name="delete-recording",
+    ),
+    path(
         "instructor-recordings/",
         RecordingsView.as_view(),
         name="instructor-recording",


### PR DESCRIPTION
**Summary:**
Created the endpoint ```instructor-recordings/{recording_id}/delete-recording``` which deletes the recording with the specified id if the recording was created by the authenticated user.

**Changes:**
1. Created the class ```DeleteRecordingView``` in ```user_views.py```
2. Added the path ```/instructor-recordings/{recording_id}/delete-recording``` to ```urls.py``` and routed it to the delete recording view.

**Manual Tests (Using Swagger):**
1. Successfully deleting a recording uploaded by my account (AustinHunter)
![success](https://github.com/user-attachments/assets/5f0d2758-06d2-4c9e-a3cb-5a60108ca5b1)

2. 404 response when attempting to delete a non-existent recording (the one deleted in test 1)
![404](https://github.com/user-attachments/assets/5abe888b-6465-43be-88d5-efa5073d9305)

3. 403 response when attempting to delete another users recording (delete request sent on account AustinHunter, audio uploaded by AustinHunter2)
![403](https://github.com/user-attachments/assets/89a3bfc7-d3a5-43ef-a644-724616b644e0)

5. 401 response when attempting to delete a recording while unauthenticated
![401](https://github.com/user-attachments/assets/8bb0d0b5-0bf2-496d-a6c7-24773a9399eb)
