### PR TITLE
Update Nginx Configuration and Add Transcript Functionality

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -1,4 +1,4 @@
-#Elastic Beanstalk Nginx Configuration File
+# Elastic Beanstalk Nginx Configuration File
 
 user                    nginx;
 error_log               /var/log/nginx/error.log warn;
@@ -11,8 +11,10 @@ events {
 }
 
 http {
+    client_max_body_size 100M;  # Adjust this value to the desired maximum file size
+
     server_tokens off;
-    
+
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 

--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -11,7 +11,7 @@ events {
 }
 
 http {
-    client_max_body_size 100M;  # Adjust this value to the desired maximum file size
+    client_max_body_size 200M;
 
     server_tokens off;
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -61,3 +61,7 @@ class InstructorRecordingsSerializer(serializers.ModelSerializer):
 
 class UpdateTranscriptSerializer(serializers.Serializer):
     transcript = serializers.CharField()
+
+
+class GetTranscriptResponseSerializer(serializers.Serializer):
+    transcript = serializers.CharField()

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -407,9 +407,6 @@ class DeleteRecordingView(APIView):
         )
 
 
-# Create a new API to get the transcript of a recording, make sure that the user is the owner of the recording
-
-
 class GetTranscriptView(APIView):
     @extend_schema(
         operation_id="get_transcript",

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -23,6 +23,7 @@ from api.models import (
 from api.serializers import (
     InstructorRecordingsSerializer,
     UpdateTranscriptSerializer,
+    GetTranscriptResponseSerializer,
 )
 from drf_spectacular.utils import extend_schema
 from drf_spectacular.types import OpenApiTypes
@@ -404,3 +405,34 @@ class DeleteRecordingView(APIView):
             {"message": "Successfully deleted recording"},
             status=status.HTTP_200_OK,
         )
+
+
+# Create a new API to get the transcript of a recording, make sure that the user is the owner of the recording
+
+
+class GetTranscriptView(APIView):
+    @extend_schema(
+        operation_id="get_transcript",
+        summary="Get transcript of a recording",
+        description="Returns the transcript of a recording with the specified ID.",
+        responses={
+            200: GetTranscriptResponseSerializer,
+            404: OpenApiTypes.OBJECT,
+            403: OpenApiTypes.OBJECT,
+        },
+    )
+    def get(self, request, recording_id):
+        instructor = request.user.instructor
+        recording = get_object_or_404(InstructorRecordings, id=recording_id)
+        if recording.instructor != instructor:
+            return JsonResponse(
+                {"message": "You do not have permission to view this recording"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        if not recording.transcript:
+            return JsonResponse(
+                {"message": "Transcript is not available yet"}, status=status.HTTP_404_NOT_FOUND
+            )
+
+        return JsonResponse({"transcript": recording.transcript}, status=status.HTTP_200_OK)

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -122,4 +122,9 @@ urlpatterns = [
         RecordingsView.as_view(),
         name="instructor-recording",
     ),
+    path(
+        "instructor-recordings/<uuid:recording_id>/get-transcript/",
+        GetTranscriptView.as_view(),
+        name="get-transcript",
+    ),
 ]


### PR DESCRIPTION
### Nginx Configuration Updates

- Added a new directive to increase the maximum size of client request bodies:
  - `client_max_body_size 200M;`

### New Serializer Class
- Introduced a new serializer for the transcript response:
  - `GetTranscriptResponseSerializer`: This class handles the serialization of the transcript data returned in API responses.

### New API View for Transcript Retrieval
- Added a new API view `GetTranscriptView` for fetching the transcript of a specific recording:
  - **Operation ID**: `get_transcript`
  - **Summary**: Defined as `Get transcript of a recording`.
  - **Functionality**:
    - Returns the transcript of the recording specified by `recording_id` if available.
    - Handles error responses for 403 Forbidden and 404 Not Found statuses.
    - Checks user permissions to ensure that only the instructor associated with the recording can access it.

### URL Routing Changes
- Updated `hice_backend/urls.py` to include a new route for the transcript retrieval view:
  - Path added: `instructor-recordings/<uuid:recording_id>/get-transcript/`
  - Associated with the `GetTranscriptView` class and named `get-transcript`.

https://github.com/user-attachments/assets/7ae4e70b-4c6a-40dc-80f0-3aebfdc80d77