### PR TITLE
Sessions by quiz id

### DIFF
--- a/api/views/session_views.py
+++ b/api/views/session_views.py
@@ -10,7 +10,6 @@ from drf_spectacular.utils import extend_schema
 from drf_spectacular.types import OpenApiTypes
 
 
-
 class StudentResponseCountView(APIView):
     def get(self, request, code):
         quiz_session = get_object_or_404(QuizSession, code=code)
@@ -176,7 +175,9 @@ class QuizSessionsByQuizView(APIView):
         instructor = request.user.instructor
         quiz = get_object_or_404(Quiz, id=quiz_id)
         if instructor != quiz.instructor:
-            return JsonResponse({"message": "You do not have permission to access this resource"}, status=403)
+            return JsonResponse(
+                {"message": "You do not have permission to access this resource"}, status=403
+            )
         sessions = QuizSession.objects.filter(quiz=quiz).order_by("start_time")
         quiz_sessions_data = [
             {
@@ -189,7 +190,7 @@ class QuizSessionsByQuizView(APIView):
             }
             for session in sessions
         ]
-        
+
         return JsonResponse({"quiz_sessions": quiz_sessions_data})
 
 

--- a/api/views/session_views.py
+++ b/api/views/session_views.py
@@ -6,6 +6,9 @@ from rest_framework.permissions import AllowAny
 from rest_framework import status
 from api.serializers import QuizSessionStudentSerializer
 from django.http import JsonResponse
+from drf_spectacular.utils import extend_schema
+from drf_spectacular.types import OpenApiTypes
+
 
 
 class StudentResponseCountView(APIView):
@@ -155,6 +158,38 @@ class QuizSessionsByInstructorView(APIView):
             for session in quiz_sessions
         ]
 
+        return JsonResponse({"quiz_sessions": quiz_sessions_data})
+
+
+class QuizSessionsByQuizView(APIView):
+    @extend_schema(
+        operation_id="quiz-sessions",
+        description="Returns all sessions of the quiz with the specified id",
+        responses={
+            200: OpenApiTypes.OBJECT,
+            401: OpenApiTypes.OBJECT,
+            404: OpenApiTypes.OBJECT,
+            403: OpenApiTypes.OBJECT,
+        },
+    )
+    def get(self, request, quiz_id):
+        instructor = request.user.instructor
+        quiz = get_object_or_404(Quiz, id=quiz_id)
+        if instructor != quiz.instructor:
+            return JsonResponse({"message": "You do not have permission to access this resource"}, status=403)
+        sessions = QuizSession.objects.filter(quiz=quiz).order_by("start_time")
+        quiz_sessions_data = [
+            {
+                "quiz_session_id": session.id,
+                "quiz_id": session.quiz.id,
+                "quiz_name": session.quiz.title,
+                "start_time": session.start_time.isoformat() if session.start_time else None,
+                "end_time": session.start_time.isoformat() if session.end_time else None,
+                "code": session.code,
+            }
+            for session in sessions
+        ]
+        
         return JsonResponse({"quiz_sessions": quiz_sessions_data})
 
 

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -93,6 +93,11 @@ urlpatterns = [
         QuizSessionsByInstructorView.as_view(),
         name="quiz-sessions-list",
     ),
+    path(
+        "quiz/<int:quiz_id>/sessions",
+        QuizSessionsByQuizView.as_view(),
+        name="quiz-sessions",
+    ),
     path("schema/", SpectacularAPIView.as_view(), name="schema"),
     path(
         "quiz-session-responses-count/<str:code>/",


### PR DESCRIPTION
**Summary:**
Created an endpoint to fetch quiz sessions by the quiz ID.

**Changes:**
1. Created the SessionsByQuizView class which contains a single get method
2. Added the endpoint ```/quiz/<quiz_id>/sessions``` to urls.py

**Manual testing with Swagger:**

**401 on unauthorized request**
![401](https://github.com/user-attachments/assets/1fcf92a3-696b-43a0-a44f-9af50e4ba897)

**403 on attempt to access another instructors quiz sessions**
![403](https://github.com/user-attachments/assets/d81c21b1-8a40-4141-aa25-4591a9a0a678)

**404 on attempt to access sessions for a non-existent quiz**
![404](https://github.com/user-attachments/assets/66e94875-3280-4416-b3c5-083c56a17fb2)

**200 on success**
![success](https://github.com/user-attachments/assets/59f04202-5268-4a2e-92bf-6e862fe59d17)
