### PR TITLE
Bug/login http code

### DIFF
--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -350,3 +350,13 @@ class QuizSessionsByInstructorViewTest(TestCase):
         self.assertIn(self.quiz_session1.code, str(response.content))
         self.assertIn(self.quiz_session2.code, str(response.content))
         self.assertIn(self.quiz.title, str(response.content))
+
+
+class LoginViewTest(BaseTest):
+    def test_post_login(self):
+        url = reverse("login")
+        data = {"username": "bad_username", "password": "bad_password!"}
+        response = self.client_student.post(url, data, format="json")
+        self.assertEqual(response.status_code, 401)
+        response_data = response.json()
+        self.assertEqual(response_data["detail"], "Invalid username or password!")

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -70,10 +70,10 @@ class Login(APIView):
         try:
             user = User.objects.get(username=request.data["username"])
         except User.DoesNotExist:
-            return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_401_UNAUTHORIZED)
+            return JsonResponse({"detail": "Invalid username or password!"}, status=status.HTTP_401_UNAUTHORIZED)
 
         if not user.check_password(request.data["password"]):
-            return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_401_UNAUTHORIZED)
+            return JsonResponse({"detail": "Invalid username or password!"}, status=status.HTTP_401_UNAUTHORIZED)
         token = Token.objects.get_or_create(user=user)
         if hasattr(user, "instructor"):
             return JsonResponse(

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -73,7 +73,7 @@ class Login(APIView):
             return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_401_UNAUTHORIZED)
 
         if not user.check_password(request.data["password"]):
-            return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_401_UNAUTHORIZED)
+            return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_400_BAD_REQUEST)
         token = Token.objects.get_or_create(user=user)
         if hasattr(user, "instructor"):
             return JsonResponse(

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -73,7 +73,7 @@ class Login(APIView):
             return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_401_UNAUTHORIZED)
 
         if not user.check_password(request.data["password"]):
-            return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_400_BAD_REQUEST)
+            return JsonResponse({"detail": "User Not Found!"}, status=status.HTTP_401_UNAUTHORIZED)
         token = Token.objects.get_or_create(user=user)
         if hasattr(user, "instructor"):
             return JsonResponse(

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -70,10 +70,14 @@ class Login(APIView):
         try:
             user = User.objects.get(username=request.data["username"])
         except User.DoesNotExist:
-            return JsonResponse({"detail": "Invalid username or password!"}, status=status.HTTP_401_UNAUTHORIZED)
+            return JsonResponse(
+                {"detail": "Invalid username or password!"}, status=status.HTTP_401_UNAUTHORIZED
+            )
 
         if not user.check_password(request.data["password"]):
-            return JsonResponse({"detail": "Invalid username or password!"}, status=status.HTTP_401_UNAUTHORIZED)
+            return JsonResponse(
+                {"detail": "Invalid username or password!"}, status=status.HTTP_401_UNAUTHORIZED
+            )
         token = Token.objects.get_or_create(user=user)
         if hasattr(user, "instructor"):
             return JsonResponse(


### PR DESCRIPTION
### Changes

- Fixed login endpoint to return only a 401 status upon failed log-in.
- Modified the response message.

### Gallery

_valid credentials_
![image](https://github.com/user-attachments/assets/ffe0cc69-78ca-4302-b0f5-9f179d20dbb0)


_invalid password_
![image](https://github.com/user-attachments/assets/c50c027f-a0c0-4550-a9b5-cdc1d59edc34)

_invalid username_
![image](https://github.com/user-attachments/assets/6f7081b2-8179-453b-af6c-234b1f98fff7)

_non-existing account_
![image](https://github.com/user-attachments/assets/7eac6425-6399-4615-8336-5ac6079ead74)

_old response_
![old_response_code](https://github.com/user-attachments/assets/3ceb1a4a-8971-44b7-841c-e5d82457e1f2)
