### PR TITLE
Enhance Quiz Retrieval Order in API

### DIFF
--- a/api/views/quiz_views.py
+++ b/api/views/quiz_views.py
@@ -19,7 +19,7 @@ class QuizView(APIView):
             return JsonResponse({"quiz": quiz.to_json()})
         else:
             instructor = get_object_or_404(Instructor, user=request.user)
-            all_quizzes = Quiz.objects.filter(instructor=instructor)
+            all_quizzes = Quiz.objects.filter(instructor=instructor).order_by("-created_at")
             quiz_response = [quiz.to_json() for quiz in all_quizzes]
             return JsonResponse({"quizzes": quiz_response})
 


### PR DESCRIPTION
This pull request modifies the quiz retrieval logic in the quiz views to ensure that quizzes are returned in a consistent order. Specifically, it updates the `get` method in `quiz_views.py` to order quizzes by their creation date in descending order. 

### Changes made:
- Updated the query for retrieving quizzes associated with an instructor:
  - **Before:** `all_quizzes = Quiz.objects.filter(instructor=instructor)`
  - **After:** `all_quizzes = Quiz.objects.filter(instructor=instructor).order_by("-created_at")`

### Benefits:
- Ensures that the most recently created quizzes appear first in the response.
- Improves the usability of the quiz retrieval endpoint for instructors, allowing them to see their latest quizzes quickly.