### PR TITLE
Add time to duration

### DIFF
--- a/api/consumers.py
+++ b/api/consumers.py
@@ -249,7 +249,6 @@ class QuizSessionInstructorConsumer(AsyncWebsocketConsumer):
             "question_opened_at": quiz_session_question.opened_at.isoformat(),
             "extension": quiz_session_question.extension,
         }
-        await self.channel_layer.group_send(f"quiz_session_{self.code}", response)
         await self.send(text_data=json.dumps(response))
 
 


### PR DESCRIPTION
**Summary:**
Added functionality to enable instructors to extend question duration times during quiz sessions. Successful extensions respond with a WebSocket message to both instructors and students.

**Changes:**
1. Created the add_to_duration_db method in the InstructorConsumer class. This method updates the extension value associated with the QuizSessionQuestion object with the given question_id and the current session code.
2. Created the add_to_duration method in the InstructorConsumer. This calls the add_to_duration_db method, sends a WebSocket message to the instructor, and propagates an event to the StudentConsumer.
3. Added the time_extended method to the StudentConsumer class. This sends a WebSocket message with details of the extension to the student.

**Examples:**
Instructor sending an increase_duration message and receiving a response.
![timeExtendedInstructor](https://github.com/user-attachments/assets/025672e3-14b3-4b38-b122-2d82e1b2ccf2)

Student receiving a message with extension updates.
![timeExtendedStudent](https://github.com/user-attachments/assets/c7c9ece8-be54-45ef-b947-b5cb376217b8)

