### PR TITLE
Change locking mechanism

### DIFF
--- a/api/consumers.py
+++ b/api/consumers.py
@@ -67,6 +67,8 @@ class QuizSessionInstructorConsumer(AsyncWebsocketConsumer):
                 await self.add_to_duration(data["question_id"], data["extension"])
             elif data["type"] == "skip_question":
                 await self.skip_question(data["question_id"])
+            elif data["type"] == "question_timer_started":
+                await self.question_timer_started(data)
 
     async def send_student_question_and_order(self, data):
         order = data.get("order")
@@ -317,6 +319,19 @@ class QuizSessionInstructorConsumer(AsyncWebsocketConsumer):
         await self.skip_question_db(question_id)
         await self.send_next_question()
 
+    @database_sync_to_async
+    def update_opened_at(self, question_id):
+        quiz_session_question = QuizSessionQuestion.objects.get(
+            question__id=question_id, quiz_session__code=self.code
+        )
+        quiz_session_question.opened_at = timezone.now()
+        quiz_session_question.save()
+        return json.dumps({"type": "question_timer_started", "status": "success"})
+
+    async def question_timer_started(self, data):
+        result = await self.update_opened_at(data["question_id"])
+        await self.send(text_data=result)
+
 
 class StudentConsumer(AsyncWebsocketConsumer):
     async def connect(self):
@@ -376,11 +391,11 @@ class StudentConsumer(AsyncWebsocketConsumer):
             )
             return False
 
-        if not quiz_session_question.unlocked:
+        if quiz_session_question.unlocked == False:
             return False
-        extension = datetime.timedelta(seconds=quiz_session_question.extension)
-        adjusted_open_time = quiz_session_question.opened_at + extension
-        return (timezone.now() - adjusted_open_time).seconds < question.duration
+        extension = quiz_session_question.extension
+        adjusted_open_time = quiz_session_question.opened_at.timestamp() + extension
+        return timezone.now().timestamp() - adjusted_open_time <= question.duration
 
     @database_sync_to_async
     def create_user_response(self, data):
@@ -415,7 +430,7 @@ class StudentConsumer(AsyncWebsocketConsumer):
             "message": "User response created successfully",
             "response_id": user_response.id,
             "question_id": data["question_id"],
-            "is_correct": is_correct,
+            "selected_answer": selected_answer,
         }
 
     @database_sync_to_async

--- a/api/consumers.py
+++ b/api/consumers.py
@@ -390,7 +390,7 @@ class StudentConsumer(AsyncWebsocketConsumer):
             )
             return False
 
-        if quiz_session_question.unlocked == False:
+        if quiz_session_question.unlocked is False:
             return False
         extension = quiz_session_question.extension
         adjusted_open_time = quiz_session_question.opened_at.timestamp() + extension

--- a/api/consumers.py
+++ b/api/consumers.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import random
-import datetime
 from collections import defaultdict
 
 from channels.generic.websocket import AsyncWebsocketConsumer


### PR DESCRIPTION
**Summary:**
Added the "question_timer_started" event to the instructor consumer and modified the is_question_open method for the student consumer. These changes enable synchronization between the client-side question timer and the back-end. 

**Changes:**
1. Modified the is_question_open method to convert the times to unix time. This simplifies the logic for determining whether or not an answer is being submitted at a valid time.

**Examples:**
Instructor sending a question_timer_started event.
![instructor-timer-started](https://github.com/user-attachments/assets/0fbdb906-2b00-46ea-b23a-79c486fc913a)

Student answering a question and later having answers rejected after the question has timed out.
![student_answers](https://github.com/user-attachments/assets/786d7119-14ac-4c86-8b50-954f4acefc30)

Instructor extending the time for the question.
![instructor-extension](https://github.com/user-attachments/assets/997f407d-69c2-4d52-b3a4-2be45aa4a69d)

Student successfully answering a question after the extension.
![student-answer-after-extension](https://github.com/user-attachments/assets/7e3d1a8f-21d3-49d5-ae7f-590741881374)
