### PR TITLE
Update Quiz and Recording Title Features

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -35,9 +35,7 @@ class InstructorSerializer(serializers.ModelSerializer):
 
 
 class QuestionMultipleChoiceSerializer(serializers.ModelSerializer):
-    quiz_id = serializers.PrimaryKeyRelatedField(
-        queryset=Quiz.objects.all(), source="quiz"
-    )
+    quiz_id = serializers.PrimaryKeyRelatedField(queryset=Quiz.objects.all(), source="quiz")
     duration = serializers.IntegerField(required=False, default=20)
 
     class Meta:
@@ -123,9 +121,7 @@ class QuizSerializer(serializers.ModelSerializer):
         settings_data = validated_data.pop("settings", {})
         settings = Settings.objects.create(**settings_data)
         instructor = self.context["request"].user.instructor
-        quiz = Quiz.objects.create(
-            instructor=instructor, settings=settings, **validated_data
-        )
+        quiz = Quiz.objects.create(instructor=instructor, settings=settings, **validated_data)
         return quiz
 
     def update(self, instance, validated_data):
@@ -144,14 +140,11 @@ class QuizSerializer(serializers.ModelSerializer):
 class QuizListSerializer(serializers.Serializer):
     quizzes = QuizSerializer(many=True)
 
-
 class QuizTitleUpdateSerializer(serializers.Serializer):
-    title = serializers.CharField(required=True, allow_blank=False)
-
+    title = serializers.CharField(required = True, allow_blank=False)
 
 class RecordingTitleUpdateSerializer(serializers.Serializer):
-    title = serializers.CharField(required=True, allow_blank=False)
-
+    title = serializers.CharField(required = True, allow_blank=False)
 
 class ContactMessageSerializer(serializers.ModelSerializer):
     class Meta:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -35,7 +35,9 @@ class InstructorSerializer(serializers.ModelSerializer):
 
 
 class QuestionMultipleChoiceSerializer(serializers.ModelSerializer):
-    quiz_id = serializers.PrimaryKeyRelatedField(queryset=Quiz.objects.all(), source="quiz")
+    quiz_id = serializers.PrimaryKeyRelatedField(
+        queryset=Quiz.objects.all(), source="quiz"
+    )
     duration = serializers.IntegerField(required=False, default=20)
 
     class Meta:
@@ -121,7 +123,9 @@ class QuizSerializer(serializers.ModelSerializer):
         settings_data = validated_data.pop("settings", {})
         settings = Settings.objects.create(**settings_data)
         instructor = self.context["request"].user.instructor
-        quiz = Quiz.objects.create(instructor=instructor, settings=settings, **validated_data)
+        quiz = Quiz.objects.create(
+            instructor=instructor, settings=settings, **validated_data
+        )
         return quiz
 
     def update(self, instance, validated_data):
@@ -139,6 +143,14 @@ class QuizSerializer(serializers.ModelSerializer):
 
 class QuizListSerializer(serializers.Serializer):
     quizzes = QuizSerializer(many=True)
+
+
+class QuizTitleUpdateSerializer(serializers.Serializer):
+    title = serializers.CharField(required=True, allow_blank=False)
+
+
+class RecordingTitleUpdateSerializer(serializers.Serializer):
+    title = serializers.CharField(required=True, allow_blank=False)
 
 
 class ContactMessageSerializer(serializers.ModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -140,11 +140,14 @@ class QuizSerializer(serializers.ModelSerializer):
 class QuizListSerializer(serializers.Serializer):
     quizzes = QuizSerializer(many=True)
 
+
 class QuizTitleUpdateSerializer(serializers.Serializer):
-    title = serializers.CharField(required = True, allow_blank=False)
+    title = serializers.CharField(required=True, allow_blank=False)
+
 
 class RecordingTitleUpdateSerializer(serializers.Serializer):
-    title = serializers.CharField(required = True, allow_blank=False)
+    title = serializers.CharField(required=True, allow_blank=False)
+
 
 class ContactMessageSerializer(serializers.ModelSerializer):
     class Meta:

--- a/api/views/quiz_views.py
+++ b/api/views/quiz_views.py
@@ -60,28 +60,31 @@ class CreateQuizView(APIView):
             )
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+
 class UpdateQuizTitleView(APIView):
     permission_classes = [IsQuizOwner]
+
     @extend_schema(
         request=QuizTitleUpdateSerializer,
-        description="Endpoint to update the title of a specific quiz"
-        )
-
+        description="Endpoint to update the title of a specific quiz",
+    )
     def patch(self, request, quiz_id):
         quiz = get_object_or_404(Quiz, id=quiz_id)
-        
+
         # Pass request data to the serializer for validation
         serializer = QuizTitleUpdateSerializer(data=request.data)
-        
+
         if serializer.is_valid():
             # If valid, update the quiz title
-            quiz.title = serializer.validated_data['title']
+            quiz.title = serializer.validated_data["title"]
             quiz.save()
-            return Response({"message": "Title updated successfully", "title": quiz.title}, status=status.HTTP_200_OK)
-        
+            return Response(
+                {"message": "Title updated successfully", "title": quiz.title},
+                status=status.HTTP_200_OK,
+            )
+
         # If not valid, return validation errors
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
 
 
 class InstructorQuizzesView(APIView):
@@ -91,7 +94,6 @@ class InstructorQuizzesView(APIView):
     def get(self, request):
         quizzes = Quiz.objects.filter(instructor=request.user.instructor)
         return Response(QuizListSerializer({"quizzes": quizzes}).data, status=status.HTTP_200_OK)
-
 
 
 class SettingsView(APIView):

--- a/api/views/quiz_views.py
+++ b/api/views/quiz_views.py
@@ -3,7 +3,11 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from api.models import *
-from api.serializers import QuizSerializer, QuizListSerializer
+from api.serializers import (
+    QuizSerializer,
+    QuizListSerializer,
+    QuizTitleUpdateSerializer,
+)
 from django.shortcuts import get_object_or_404
 from django.http import JsonResponse
 
@@ -61,13 +65,43 @@ class CreateQuizView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+class UpdateQuizTitleView(APIView):
+    permission_classes = [IsQuizOwner]
+
+    @extend_schema(
+        request=QuizTitleUpdateSerializer,
+        description="Endpoint to update the title of a specific quiz",
+    )
+    def patch(self, request, quiz_id):
+        quiz = get_object_or_404(Quiz, id=quiz_id)
+
+        # Pass request data to the serializer for validation
+        serializer = QuizTitleUpdateSerializer(data=request.data)
+
+        if serializer.is_valid():
+            # If valid, update the quiz title
+            quiz.title = serializer.validated_data["title"]
+            quiz.save()
+            return Response(
+                {"message": "Title updated successfully", "title": quiz.title},
+                status=status.HTTP_200_OK,
+            )
+
+        # If not valid, return validation errors
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
 class InstructorQuizzesView(APIView):
     permission_class = [AllowInstructor]
 
-    @extend_schema(responses={200: QuizListSerializer}, summary="Get all quizzes by instructor")
+    @extend_schema(
+        responses={200: QuizListSerializer}, summary="Get all quizzes by instructor"
+    )
     def get(self, request):
         quizzes = Quiz.objects.filter(instructor=request.user.instructor)
-        return Response(QuizListSerializer({"quizzes": quizzes}).data, status=status.HTTP_200_OK)
+        return Response(
+            QuizListSerializer({"quizzes": quizzes}).data, status=status.HTTP_200_OK
+        )
 
 
 class SettingsView(APIView):

--- a/api/views/quiz_views.py
+++ b/api/views/quiz_views.py
@@ -3,11 +3,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from api.models import *
-from api.serializers import (
-    QuizSerializer,
-    QuizListSerializer,
-    QuizTitleUpdateSerializer,
-)
+from api.serializers import QuizSerializer, QuizListSerializer, QuizTitleUpdateSerializer
 from django.shortcuts import get_object_or_404
 from django.http import JsonResponse
 
@@ -64,44 +60,38 @@ class CreateQuizView(APIView):
             )
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-
 class UpdateQuizTitleView(APIView):
     permission_classes = [IsQuizOwner]
-
     @extend_schema(
         request=QuizTitleUpdateSerializer,
-        description="Endpoint to update the title of a specific quiz",
-    )
+        description="Endpoint to update the title of a specific quiz"
+        )
+
     def patch(self, request, quiz_id):
         quiz = get_object_or_404(Quiz, id=quiz_id)
-
+        
         # Pass request data to the serializer for validation
         serializer = QuizTitleUpdateSerializer(data=request.data)
-
+        
         if serializer.is_valid():
             # If valid, update the quiz title
-            quiz.title = serializer.validated_data["title"]
+            quiz.title = serializer.validated_data['title']
             quiz.save()
-            return Response(
-                {"message": "Title updated successfully", "title": quiz.title},
-                status=status.HTTP_200_OK,
-            )
-
+            return Response({"message": "Title updated successfully", "title": quiz.title}, status=status.HTTP_200_OK)
+        
         # If not valid, return validation errors
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
 
 
 class InstructorQuizzesView(APIView):
     permission_class = [AllowInstructor]
 
-    @extend_schema(
-        responses={200: QuizListSerializer}, summary="Get all quizzes by instructor"
-    )
+    @extend_schema(responses={200: QuizListSerializer}, summary="Get all quizzes by instructor")
     def get(self, request):
         quizzes = Quiz.objects.filter(instructor=request.user.instructor)
-        return Response(
-            QuizListSerializer({"quizzes": quizzes}).data, status=status.HTTP_200_OK
-        )
+        return Response(QuizListSerializer({"quizzes": quizzes}).data, status=status.HTTP_200_OK)
+
 
 
 class SettingsView(APIView):

--- a/api/views/recordings_views.py
+++ b/api/views/recordings_views.py
@@ -4,10 +4,7 @@ from rest_framework.permissions import IsAuthenticated
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 
-from api.serializers import (
-    InstructorRecordingsSerializer,
-    RecordingTitleUpdateSerializer,
-)
+from api.serializers import InstructorRecordingsSerializer, RecordingTitleUpdateSerializer
 from django.conf import settings
 from django.shortcuts import get_object_or_404
 
@@ -72,29 +69,25 @@ class GenerateTemporaryCredentialsView(APIView):
         except Exception as e:
             return Response({"error": str(e)}, status=500)
 
-
 class UpdateRecordingTitleView(APIView):
     permission_classes = [IsAuthenticated]
-
     @extend_schema(
         request=RecordingTitleUpdateSerializer,
-        description="Endpoint to update the title of a recording",
-    )
+        description="Endpoint to update the title of a recording"
+        )
+
     def patch(self, request, recording_id):
         recording = get_object_or_404(InstructorRecordings, id=recording_id)
-
+        
         # Pass request data to the serializer for validation
         serializer = RecordingTitleUpdateSerializer(data=request.data)
-
+        
         if serializer.is_valid():
             # If valid, update the quiz title
-            recording.title = serializer.validated_data["title"]
+            recording.title = serializer.validated_data['title']
             recording.save()
-            return Response(
-                {"message": "Title updated successfully", "title": recording.title},
-                status=status.HTTP_200_OK,
-            )
-
+            return Response({"message": "Title updated successfully", "title": recording.title}, status=status.HTTP_200_OK)
+        
         # If not valid, return validation errors
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -121,9 +114,7 @@ class CreateRecordingView(APIView):
         serializer = InstructorRecordingsSerializer(data=data)
         if serializer.is_valid():
             serializer.save()
-            new_recording = (
-                serializer.instance
-            )  # Get the newly created recording instance
+            new_recording = serializer.instance  # Get the newly created recording instance
 
             # Invoke the Lambda function asynchronously
             try:
@@ -153,9 +144,7 @@ class CreateRecordingView(APIView):
             except Exception as e:
                 # Handle Lambda invocation errors if necessary
                 return Response(
-                    {
-                        "error": f"Recording saved, but failed to invoke Lambda: {str(e)}"
-                    },
+                    {"error": f"Recording saved, but failed to invoke Lambda: {str(e)}"},
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
 

--- a/api/views/recordings_views.py
+++ b/api/views/recordings_views.py
@@ -69,25 +69,29 @@ class GenerateTemporaryCredentialsView(APIView):
         except Exception as e:
             return Response({"error": str(e)}, status=500)
 
+
 class UpdateRecordingTitleView(APIView):
     permission_classes = [IsAuthenticated]
+
     @extend_schema(
         request=RecordingTitleUpdateSerializer,
-        description="Endpoint to update the title of a recording"
-        )
-
+        description="Endpoint to update the title of a recording",
+    )
     def patch(self, request, recording_id):
         recording = get_object_or_404(InstructorRecordings, id=recording_id)
-        
+
         # Pass request data to the serializer for validation
         serializer = RecordingTitleUpdateSerializer(data=request.data)
-        
+
         if serializer.is_valid():
             # If valid, update the quiz title
-            recording.title = serializer.validated_data['title']
+            recording.title = serializer.validated_data["title"]
             recording.save()
-            return Response({"message": "Title updated successfully", "title": recording.title}, status=status.HTTP_200_OK)
-        
+            return Response(
+                {"message": "Title updated successfully", "title": recording.title},
+                status=status.HTTP_200_OK,
+            )
+
         # If not valid, return validation errors
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/api/views/recordings_views.py
+++ b/api/views/recordings_views.py
@@ -80,17 +80,18 @@ class UpdateRecordingTitleView(APIView):
     def patch(self, request, recording_id):
         recording = get_object_or_404(InstructorRecordings, id=recording_id)
 
+        # check if owned by requested user
+        if request.user != recording.instructor.user:
+            return Response(
+                {"error": "You do not have permission to modify this recording."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         # Pass request data to the serializer for validation
         serializer = RecordingTitleUpdateSerializer(data=request.data)
 
         if serializer.is_valid():
-            # If valid, update the recording title if owned by user
-            if request.user.id != recording.instructor.user.id:
-                return Response(
-                    {"error": "You do not have permission to modify this recording."},
-                    status=status.HTTP_403_FORBIDDEN,
-                )
-
+            # If valid, update the recording title
             recording.title = serializer.validated_data["title"]
             recording.save()
             return Response(

--- a/api/views/recordings_views.py
+++ b/api/views/recordings_views.py
@@ -84,7 +84,13 @@ class UpdateRecordingTitleView(APIView):
         serializer = RecordingTitleUpdateSerializer(data=request.data)
 
         if serializer.is_valid():
-            # If valid, update the quiz title
+            # If valid, update the recording title if owned by user
+            if request.user.id != recording.instructor.user.id:
+                return Response(
+                    {"error": "You do not have permission to modify this recording."},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
             recording.title = serializer.validated_data["title"]
             recording.save()
             return Response(

--- a/api/views/session_views.py
+++ b/api/views/session_views.py
@@ -13,16 +13,12 @@ from drf_spectacular.types import OpenApiTypes
 class StudentResponseCountView(APIView):
     def get(self, request, code):
         quiz_session = get_object_or_404(QuizSession, code=code)
-        responses = quiz_session.responses.filter(
-            question_id=quiz_session.current_question
-        )
+        responses = quiz_session.responses.filter(question_id=quiz_session.current_question)
 
         counts = {}
         for response in responses:
             # Increment the count for the selected answer or initialize it to 0 if not found
-            counts[response.selected_answer] = (
-                counts.get(response.selected_answer, 0) + 1
-            )
+            counts[response.selected_answer] = counts.get(response.selected_answer, 0) + 1
 
         return Response(counts, status=200)
 
@@ -62,9 +58,7 @@ class QuizSessionView(APIView):
                 status=status.HTTP_201_CREATED,
             )
         except Exception as e:
-            return Response(
-                {"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 class QuizSessionStudentView(APIView):
@@ -130,9 +124,7 @@ class QuizSessionResults(APIView):
         results = []
         for student in students:
             total_questions = UserResponse.objects.filter(student=student).count()
-            correct_answers = UserResponse.objects.filter(
-                student=student, is_correct=True
-            ).count()
+            correct_answers = UserResponse.objects.filter(student=student, is_correct=True).count()
 
             results.append(
                 {
@@ -149,18 +141,16 @@ class QuizSessionsByInstructorView(APIView):
     def get(self, request):
         instructor = request.user.instructor
 
-        quiz_sessions = QuizSession.objects.filter(
-            quiz__instructor=instructor
-        ).order_by("quiz_id", "start_time")
+        quiz_sessions = QuizSession.objects.filter(quiz__instructor=instructor).order_by(
+            "quiz_id", "start_time"
+        )
 
         quiz_sessions_data = [
             {
                 "quiz_session_id": session.id,
                 "quiz_id": session.quiz.id,
                 "quiz_name": session.quiz.title,
-                "start_time": (
-                    session.start_time.isoformat() if session.start_time else None
-                ),
+                "start_time": (session.start_time.isoformat() if session.start_time else None),
                 "end_time": session.end_time.isoformat() if session.end_time else None,
                 "code": session.code,
             }
@@ -195,12 +185,8 @@ class QuizSessionsByQuizView(APIView):
                 "quiz_session_id": session.id,
                 "quiz_id": session.quiz.id,
                 "quiz_name": session.quiz.title,
-                "start_time": (
-                    session.start_time.isoformat() if session.start_time else None
-                ),
-                "end_time": (
-                    session.start_time.isoformat() if session.end_time else None
-                ),
+                "start_time": (session.start_time.isoformat() if session.start_time else None),
+                "end_time": (session.start_time.isoformat() if session.end_time else None),
                 "code": session.code,
                 "num_of_participants": session.students.count(),
             }
@@ -214,9 +200,7 @@ class NextQuestionAPIView(APIView):
     def get(self, request, session_code):
         try:
             session = QuizSession.objects.get(code=session_code)
-            served_questions_ids = session.served_questions.all().values_list(
-                "id", flat=True
-            )
+            served_questions_ids = session.served_questions.all().values_list("id", flat=True)
             next_question = (
                 QuestionMultipleChoice.objects.exclude(id__in=served_questions_ids)
                 .filter(quiz=session.quiz)
@@ -277,6 +261,4 @@ class DeleteQuizSession(APIView):
         except QuizSession.DoesNotExist:
             return Response({"message": "Invalid session code."}, status=404)
         except Exception as e:
-            return Response(
-                {"message": f"{str(e)}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+            return Response({"message": f"{str(e)}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/api/views/session_views.py
+++ b/api/views/session_views.py
@@ -13,12 +13,16 @@ from drf_spectacular.types import OpenApiTypes
 class StudentResponseCountView(APIView):
     def get(self, request, code):
         quiz_session = get_object_or_404(QuizSession, code=code)
-        responses = quiz_session.responses.filter(question_id=quiz_session.current_question)
+        responses = quiz_session.responses.filter(
+            question_id=quiz_session.current_question
+        )
 
         counts = {}
         for response in responses:
             # Increment the count for the selected answer or initialize it to 0 if not found
-            counts[response.selected_answer] = counts.get(response.selected_answer, 0) + 1
+            counts[response.selected_answer] = (
+                counts.get(response.selected_answer, 0) + 1
+            )
 
         return Response(counts, status=200)
 
@@ -58,7 +62,9 @@ class QuizSessionView(APIView):
                 status=status.HTTP_201_CREATED,
             )
         except Exception as e:
-            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 class QuizSessionStudentView(APIView):
@@ -124,7 +130,9 @@ class QuizSessionResults(APIView):
         results = []
         for student in students:
             total_questions = UserResponse.objects.filter(student=student).count()
-            correct_answers = UserResponse.objects.filter(student=student, is_correct=True).count()
+            correct_answers = UserResponse.objects.filter(
+                student=student, is_correct=True
+            ).count()
 
             results.append(
                 {
@@ -141,16 +149,18 @@ class QuizSessionsByInstructorView(APIView):
     def get(self, request):
         instructor = request.user.instructor
 
-        quiz_sessions = QuizSession.objects.filter(quiz__instructor=instructor).order_by(
-            "quiz_id", "start_time"
-        )
+        quiz_sessions = QuizSession.objects.filter(
+            quiz__instructor=instructor
+        ).order_by("quiz_id", "start_time")
 
         quiz_sessions_data = [
             {
                 "quiz_session_id": session.id,
                 "quiz_id": session.quiz.id,
                 "quiz_name": session.quiz.title,
-                "start_time": (session.start_time.isoformat() if session.start_time else None),
+                "start_time": (
+                    session.start_time.isoformat() if session.start_time else None
+                ),
                 "end_time": session.end_time.isoformat() if session.end_time else None,
                 "code": session.code,
             }
@@ -185,8 +195,12 @@ class QuizSessionsByQuizView(APIView):
                 "quiz_session_id": session.id,
                 "quiz_id": session.quiz.id,
                 "quiz_name": session.quiz.title,
-                "start_time": (session.start_time.isoformat() if session.start_time else None),
-                "end_time": (session.start_time.isoformat() if session.end_time else None),
+                "start_time": (
+                    session.start_time.isoformat() if session.start_time else None
+                ),
+                "end_time": (
+                    session.start_time.isoformat() if session.end_time else None
+                ),
                 "code": session.code,
                 "num_of_participants": session.students.count(),
             }
@@ -200,7 +214,9 @@ class NextQuestionAPIView(APIView):
     def get(self, request, session_code):
         try:
             session = QuizSession.objects.get(code=session_code)
-            served_questions_ids = session.served_questions.all().values_list("id", flat=True)
+            served_questions_ids = session.served_questions.all().values_list(
+                "id", flat=True
+            )
             next_question = (
                 QuestionMultipleChoice.objects.exclude(id__in=served_questions_ids)
                 .filter(quiz=session.quiz)
@@ -261,4 +277,6 @@ class DeleteQuizSession(APIView):
         except QuizSession.DoesNotExist:
             return Response({"message": "Invalid session code."}, status=404)
         except Exception as e:
-            return Response({"message": f"{str(e)}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"message": f"{str(e)}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )

--- a/api/views/session_views.py
+++ b/api/views/session_views.py
@@ -262,5 +262,3 @@ class DeleteQuizSession(APIView):
             return Response({"message": "Invalid session code."}, status=404)
         except Exception as e:
             return Response({"message": f"{str(e)}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -12,6 +12,11 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("quiz/<int:quiz_id>/", QuizView.as_view(), name="quiz-detail"),
+    path(
+        "quiz/<int:quiz_id>/update-title/",
+        UpdateQuizTitleView.as_view(),
+        name="quiz-update-title",
+    ),
     path("question/", QuestionView.as_view(), name="question-list"),
     path("question/<int:question_id>/", QuestionView.as_view(), name="question-detail"),
     path(
@@ -30,7 +35,11 @@ urlpatterns = [
         InstructorView.as_view(),
         name="instructor-detail",
     ),
-    path("instructor/quizzes/", InstructorQuizzesView.as_view(), name="instructor-quizzes"),
+    path(
+        "instructor/quizzes/",
+        InstructorQuizzesView.as_view(),
+        name="instructor-quizzes",
+    ),
     # path('student/', StudentView.as_view(), name='student-list'),
     # path('student/<int:student_id>/', StudentView.as_view(), name='student-detail'),
     path("user-response/", UserResponseView.as_view(), name="user-response-list"),
@@ -143,6 +152,11 @@ urlpatterns = [
         "instructor-recordings/<uuid:recording_id>/get-transcript/",
         GetTranscriptView.as_view(),
         name="get-transcript",
+    ),
+    path(
+        "instructor-recordings/<uuid:recording_id>/update-title/",
+        UpdateRecordingTitleView.as_view(),
+        name="recording-update-title",
     ),
     path("auth/google/", GoogleLogin.as_view()),  # Route for Google login
     path("contact-us/", ContactPageView.as_view(), name="contact-us"),

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -12,7 +12,9 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("quiz/<int:quiz_id>/", QuizView.as_view(), name="quiz-detail"),
-    path("quiz/<int:quiz_id>/update-title/", UpdateQuizTitleView.as_view(), name="quiz-update-title"),
+    path(
+        "quiz/<int:quiz_id>/update-title/", UpdateQuizTitleView.as_view(), name="quiz-update-title"
+    ),
     path("question/", QuestionView.as_view(), name="question-list"),
     path("question/<int:question_id>/", QuestionView.as_view(), name="question-detail"),
     path(
@@ -145,10 +147,11 @@ urlpatterns = [
         GetTranscriptView.as_view(),
         name="get-transcript",
     ),
-    path("instructor-recordings/<uuid:recording_id>/update-title/",
-         UpdateRecordingTitleView.as_view(),
-         name="recording-update-title"
-         ),
+    path(
+        "instructor-recordings/<uuid:recording_id>/update-title/",
+        UpdateRecordingTitleView.as_view(),
+        name="recording-update-title",
+    ),
     path("auth/google/", GoogleLogin.as_view()),  # Route for Google login
     path("contact-us/", ContactPageView.as_view(), name="contact-us"),
     path("profile/", ProfileView.as_view(), name="profile"),

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -12,11 +12,7 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("quiz/<int:quiz_id>/", QuizView.as_view(), name="quiz-detail"),
-    path(
-        "quiz/<int:quiz_id>/update-title/",
-        UpdateQuizTitleView.as_view(),
-        name="quiz-update-title",
-    ),
+    path("quiz/<int:quiz_id>/update-title/", UpdateQuizTitleView.as_view(), name="quiz-update-title"),
     path("question/", QuestionView.as_view(), name="question-list"),
     path("question/<int:question_id>/", QuestionView.as_view(), name="question-detail"),
     path(
@@ -35,11 +31,7 @@ urlpatterns = [
         InstructorView.as_view(),
         name="instructor-detail",
     ),
-    path(
-        "instructor/quizzes/",
-        InstructorQuizzesView.as_view(),
-        name="instructor-quizzes",
-    ),
+    path("instructor/quizzes/", InstructorQuizzesView.as_view(), name="instructor-quizzes"),
     # path('student/', StudentView.as_view(), name='student-list'),
     # path('student/<int:student_id>/', StudentView.as_view(), name='student-detail'),
     path("user-response/", UserResponseView.as_view(), name="user-response-list"),
@@ -153,11 +145,10 @@ urlpatterns = [
         GetTranscriptView.as_view(),
         name="get-transcript",
     ),
-    path(
-        "instructor-recordings/<uuid:recording_id>/update-title/",
-        UpdateRecordingTitleView.as_view(),
-        name="recording-update-title",
-    ),
+    path("instructor-recordings/<uuid:recording_id>/update-title/",
+         UpdateRecordingTitleView.as_view(),
+         name="recording-update-title"
+         ),
     path("auth/google/", GoogleLogin.as_view()),  # Route for Google login
     path("contact-us/", ContactPageView.as_view(), name="contact-us"),
     path("profile/", ProfileView.as_view(), name="profile"),


### PR DESCRIPTION
This pull request introduces enhancements to allow updating the titles of quizzes and recordings. The changes are as follows:

## Changes Made:

- **Added serializers for title updates**:
  - Introduced `QuizTitleUpdateSerializer` for validating updates to quiz titles.
  - Introduced `RecordingTitleUpdateSerializer` for validating updates to recording titles.

- **New API views for title updates**:
  - Created `UpdateQuizTitleView`:
    - Handles `PATCH` requests to update the title of a quiz.
    - Validates incoming data against `QuizTitleUpdateSerializer`.
    - Returns appropriate success or error messages based on validation.
  - Created `UpdateRecordingTitleView`:
    - Handles `PATCH` requests to update the title of a recording.
    - Validates incoming data against `RecordingTitleUpdateSerializer`.
    - Returns success messages with the new title or errors if validation fails.

- **Updated URL configurations**:
  - Registered a new endpoint for updating quiz titles:
    - `PUT /quiz/<quiz_id>/update-title/`
  - Registered a new endpoint for updating recording titles:
    - `PUT /instructor-recordings/<recording_id>/update-title/`

- **Code cleanup and formatting improvements**:
  - Improved formatting in several places for better readability.
  - Ensured consistent indentation and layout across the new and existing code.