### PR TITLE
Refactor Audio Upload and Recording Management URLs

### DIFF
--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -130,7 +130,7 @@ urlpatterns = [
     path(
         "instructor-recordings/<uuid:recording_id>/update-transcript/",
         UpdateTranscriptView.as_view(),
-        name="update-transcript",
+        name="update-transcript-will-be-deprecated",
     ),
     path(
         "recordings/<uuid:recording_id>/update-transcript/",
@@ -140,7 +140,7 @@ urlpatterns = [
     path(
         "instructor-recordings/<uuid:recording_id>/delete-recording",
         DeleteRecordingView.as_view(),
-        name="delete-recording",
+        name="delete-recording-will-be-deprecated",
     ),
     path(
         "recordings/<uuid:recording_id>/delete-recording",
@@ -150,7 +150,7 @@ urlpatterns = [
     path(
         "instructor-recordings/<uuid:recording_id>/update-duration/",
         UpdateRecordingDurationView.as_view(),
-        name="update-recording-duration",
+        name="update-recording-duration-will-be-deprecated",
     ),
     path(
         "recordings/<uuid:recording_id>/update-duration/",
@@ -160,7 +160,7 @@ urlpatterns = [
     path(
         "instructor-recordings/",
         RecordingsView.as_view(),
-        name="instructor-recording",
+        name="instructor-recording-will-be-deprecated",
     ),
     path(
         "recordings/",
@@ -170,7 +170,7 @@ urlpatterns = [
     path(
         "instructor-recordings/<uuid:recording_id>/get-transcript/",
         GetTranscriptView.as_view(),
-        name="get-transcript",
+        name="get-transcript-will-be-deprecated",
     ),
     path(
         "recordings/<uuid:recording_id>/get-transcript/",
@@ -180,7 +180,7 @@ urlpatterns = [
     path(
         "instructor-recordings/<uuid:recording_id>/update-title/",
         UpdateRecordingTitleView.as_view(),
-        name="recording-update-title",
+        name="recording-update-title-will-be-deprecated",
     ),
     path(
         "recordings/<uuid:recording_id>/update-title/",

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -133,7 +133,17 @@ urlpatterns = [
         name="update-transcript",
     ),
     path(
+        "recordings/<uuid:recording_id>/update-transcript/",
+        UpdateTranscriptView.as_view(),
+        name="update-transcript",
+    ),
+    path(
         "instructor-recordings/<uuid:recording_id>/delete-recording",
+        DeleteRecordingView.as_view(),
+        name="delete-recording",
+    ),
+    path(
+        "recordings/<uuid:recording_id>/delete-recording",
         DeleteRecordingView.as_view(),
         name="delete-recording",
     ),
@@ -143,7 +153,17 @@ urlpatterns = [
         name="update-recording-duration",
     ),
     path(
+        "recordings/<uuid:recording_id>/update-duration/",
+        UpdateRecordingDurationView.as_view(),
+        name="update-recording-duration",
+    ),
+    path(
         "instructor-recordings/",
+        RecordingsView.as_view(),
+        name="instructor-recording",
+    ),
+    path(
+        "recordings/",
         RecordingsView.as_view(),
         name="instructor-recording",
     ),
@@ -153,7 +173,17 @@ urlpatterns = [
         name="get-transcript",
     ),
     path(
+        "recordings/<uuid:recording_id>/get-transcript/",
+        GetTranscriptView.as_view(),
+        name="get-transcript",
+    ),
+    path(
         "instructor-recordings/<uuid:recording_id>/update-title/",
+        UpdateRecordingTitleView.as_view(),
+        name="recording-update-title",
+    ),
+    path(
+        "recordings/<uuid:recording_id>/update-title/",
         UpdateRecordingTitleView.as_view(),
         name="recording-update-title",
     ),

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -126,7 +126,8 @@ urlpatterns = [
         name="swagger-ui",
     ),
     path("check-developer/", CheckDeveloperStatus.as_view(), name="check-developer"),
-    path("upload-audio/", UploadAudioView.as_view(), name="upload-audio"),
+    path("upload-audio/", UploadAudioView.as_view(), name="upload-audio-will-be-deprecated"),
+    path("recordings/upload-audio/", UploadAudioView.as_view(), name="upload-audio"),
     path(
         "instructor-recordings/<uuid:recording_id>/update-transcript/",
         UpdateTranscriptView.as_view(),
@@ -198,6 +199,11 @@ urlpatterns = [
     ),
     path(
         "create-recording/",
+        CreateRecordingView.as_view(),
+        name="create-recording-will-be-deprecated",
+    ),
+    path(
+        "recordings/create-recording/",
         CreateRecordingView.as_view(),
         name="create-recording",
     ),


### PR DESCRIPTION
This pull request introduces a refactor of the audio upload and recording management URL paths in the Django application. The updates enhance clarity and maintainability, while preparing for future deprecations. The changes include the following key modifications:

- **Upload Audio Paths**:
  - Updated the existing upload audio path to be marked as deprecated:
    - `upload-audio/` is now renamed to `upload-audio-will-be-deprecated`.
  - A new path for uploading audio recordings under a structured namespace has been added:
    - `recordings/upload-audio/`.

- **Update Transcript Paths**:
  - Marked the instructor-specific transcript update path as deprecated:
    - `instructor-recordings/<uuid:recording_id>/update-transcript/` is now `update-transcript-will-be-deprecated`.
  - Added a new path for the same functionality targeting general recordings:
    - `recordings/<uuid:recording_id>/update-transcript/`.

- **Delete Recording Paths**:
  - The instructor-specific delete recording path has been deprecated:
    - `instructor-recordings/<uuid:recording_id>/delete-recording` is now `delete-recording-will-be-deprecated`.
  - A new, more generic delete recording path has been added:
    - `recordings/<uuid:recording_id>/delete-recording`.

- **Update Recording Duration Paths**:
  - The instructor-specific duration update path is now deprecated:
    - `instructor-recordings/<uuid:recording_id>/update-duration/` has a new name `update-recording-duration-will-be-deprecated`.
  - A generic update duration path has been added:
    - `recordings/<uuid:recording_id>/update-duration/`.

- **Recordings View Paths**:
  - The instructor-specific recordings view has been marked as deprecated:
    - `instructor-recordings/` will now be referenced as `instructor-recording-will-be-deprecated`.
  - A parallel generic recordings view has also been introduced:
    - `recordings/`.

- **Get Transcript Paths**:
  - Marked the instructor-specific get transcript path as deprecated:
    - `instructor-recordings/<uuid:recording_id>/get-transcript/` has been changed to `get-transcript-will-be-deprecated`.
  - Added a generic path for fetching transcripts:
    - `recordings/<uuid:recording_id>/get-transcript/`.

- **Update Recording Title Paths**:
  - The instructor-specific update title path has been marked as deprecated:
    - `instructor-recordings/<uuid:recording_id>/update-title/` renamed to `recording-update-title-will-be-deprecated`.
  - A generic path for updating recording title has been established:
    - `recordings/<uuid:recording_id>/update-title/`.

- **Create Recording Paths**:
  - The instructor-specific create recording path has been marked as deprecated:
    - `create-recording/` is now referred to as `create-recording-will-be-deprecated`.
  - A new path for creating recordings in a generic manner has been added:
    - `recordings/create-recording/`.

These adjustments aim to provide a clearer API structure while signaling future deprecations to users and maintainers.