### PR TITLE
# Add Lecture Summary Retrieval Feature

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,5 +1,12 @@
 from rest_framework import permissions
-from .models import Instructor, Quiz, QuestionMultipleChoice, InstructorRecordings, QuizSession
+from .models import (
+    Instructor,
+    Quiz,
+    QuestionMultipleChoice,
+    InstructorRecordings,
+    QuizSession,
+    LectureSummary,
+)
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned, FieldError
 
 
@@ -101,3 +108,19 @@ class IsSessionOwner(permissions.BasePermission):
         except (ObjectDoesNotExist, MultipleObjectsReturned, FieldError):
             return False
         return request.user == session.quiz.instructor.user
+
+
+class IsSummaryOwner(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        # Get summary_id from the URL
+        summary_id = view.kwargs.get("summary_id")
+
+        try:
+            # Retrieve the LectureSummary and verify the ownership of the recording
+            summary = LectureSummary.objects.get(id=summary_id)
+        except (ObjectDoesNotExist, MultipleObjectsReturned, FieldError):
+            return False
+        return request.user == summary.recording.instructor.user

--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -768,6 +768,13 @@ class LectureSummaryByIdViewTest(BaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_get_summary_by_id_forbidden(self):
+        # non owner
+        url = reverse("get-summary", kwargs={"summary_id": str(self.lecture_summary.id)})
+        response = self.client_instructor_two.get(url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
 
 class RecordingTitleChangeTest(BaseTest):
     def setUp(self):

--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -734,8 +734,8 @@ class LectureSummaryViewTest(BaseTest):
         response = self.client_instructor.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]["summary"], "Test Summary 2")
-        self.assertEqual(response.data[1]["summary"], "Test Summary 1")
+        self.assertEqual(response.data[0]["summary"], "Test Summary 1")
+        self.assertEqual(response.data[1]["summary"], "Test Summary 2")
 
     def test_get_lecture_summary_forbidden(self):
         url = reverse("lecture_summary", kwargs={"recording_id": str(self.recording.id)})
@@ -748,20 +748,17 @@ class LectureSummaryByIdViewTest(BaseTest):
         super().setUp()
         # Set up a sample InstructorRecordings instance for valid recording_id tests
         self.recording = InstructorRecordings.objects.create(instructor=self.instructor)
-        self.lecture_summary_1 = LectureSummary.objects.create(
+        self.lecture_summary = LectureSummary.objects.create(
             summary="Test Summary", recording=self.recording
-        )
-        self.lecture_summary_2 = LectureSummary.objects.create(
-            summary="Test Summary 2", recording=self.recording
         )
 
     def test_get_summary_by_id_successful(self):
         # Valid summary_id
-        url = reverse("get-summary", kwargs={"summary_id": str(self.lecture_summary_1.id)})
+        url = reverse("get-summary", kwargs={"summary_id": str(self.lecture_summary.id)})
         response = self.client_instructor.get(url, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["summary"], self.lecture_summary_1.summary)
+        self.assertEqual(response.data["summary"], self.lecture_summary.summary)
 
     def test_get_summary_by_id_not_found(self):
         # Non-existent summary_id

--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -743,6 +743,35 @@ class LectureSummaryViewTest(BaseTest):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
+class LectureSummaryByIdViewTest(BaseTest):
+    def setUp(self):
+        super().setUp()
+        # Set up a sample InstructorRecordings instance for valid recording_id tests
+        self.recording = InstructorRecordings.objects.create(instructor=self.instructor)
+        self.lecture_summary_1 = LectureSummary.objects.create(
+            summary="Test Summary", recording=self.recording
+        )
+        self.lecture_summary_2 = LectureSummary.objects.create(
+            summary="Test Summary 2", recording=self.recording
+        )
+
+    def test_get_summary_by_id_successful(self):
+        # Valid summary_id
+        url = reverse("get-summary", kwargs={"summary_id": str(self.lecture_summary_1.id)})
+        response = self.client_instructor.get(url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["summary"], self.lecture_summary_1.summary)
+
+    def test_get_summary_by_id_not_found(self):
+        # Non-existent summary_id
+        non_existent_id = "127ac01a-379b-44af-97e6-286bac44ff7f"
+        url = reverse("get-summary", kwargs={"summary_id": non_existent_id})
+        response = self.client_instructor.get(url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
 class RecordingTitleChangeTest(BaseTest):
     def setUp(self):
         super().setUp()

--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -734,8 +734,8 @@ class LectureSummaryViewTest(BaseTest):
         response = self.client_instructor.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]["summary"], "Test Summary 1")
-        self.assertEqual(response.data[1]["summary"], "Test Summary 2")
+        self.assertEqual(response.data[0]["summary"], "Test Summary 2")
+        self.assertEqual(response.data[1]["summary"], "Test Summary 1")
 
     def test_get_lecture_summary_forbidden(self):
         url = reverse("lecture_summary", kwargs={"recording_id": str(self.recording.id)})

--- a/api/views/session_views.py
+++ b/api/views/session_views.py
@@ -20,7 +20,7 @@ from django.http import JsonResponse
 from drf_spectacular.utils import extend_schema
 from drf_spectacular.types import OpenApiTypes
 
-from ..permissions import IsQuizOwner, AllowInstructor, IsSessionOwner
+from ..permissions import IsQuizOwner, AllowInstructor, IsSessionOwner, IsSummaryOwner
 
 
 @extend_schema(tags=["Session Activities"])
@@ -299,7 +299,7 @@ class DeleteQuizSession(APIView):
             return Response({"message": f"{str(e)}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-@extend_schema(tags=["Recordings"])
+@extend_schema(tags=["Summaries"])
 class LectureSummaryView(APIView):
     permission_classes = [IsRecordingOwner]
 
@@ -352,4 +352,26 @@ class LectureSummaryView(APIView):
     def get(self, request, recording_id):
         lecture_summary = LectureSummary.objects.filter(recording=recording_id)
         serializer = LectureSummarySerializer(lecture_summary, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@extend_schema(tags=["Summaries"])
+class LectureSummaryByIdView(APIView):
+    permission_classes = [IsSummaryOwner]
+
+    @extend_schema(
+        operation_id="get_lecture_summary",
+        summary="Get lecture summary from a summary id",
+        description="Get a summary for a specific recording using the summary ID.",
+        request=LectureSummarySerializer,
+        responses={
+            200: OpenApiTypes.OBJECT,  # Successful retrieval of data.
+            403: OpenApiTypes.OBJECT,  # Response when the user is not authorized to proceed with the request.
+            404: OpenApiTypes.OBJECT,  # Response when object is not found
+            500: OpenApiTypes.OBJECT,  # Response when there is an error from the server side.
+        },
+    )
+    def get(self, request, summary_id):
+        summary = LectureSummary.objects.get(id=summary_id)
+        serializer = LectureSummarySerializer(summary)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -182,6 +182,11 @@ urlpatterns = [
         name="lecture_summary",
     ),
     path(
+        "summary/<uuid:summary_id>/get-summary/",
+        LectureSummaryByIdView.as_view(),
+        name="get-summary",
+    ),
+    path(
         "token/verify/",
         TokenVerificationView.as_view(),
         name="verify-token",


### PR DESCRIPTION
This pull request introduces a new feature for retrieving lecture summaries by their unique ID. The following changes were made to implement this functionality:

- **Updated `api/permissions.py`:**
  - **Imported `LectureSummary` Model:** Added the LectureSummary model to handle the new permission related to lecture summaries.
  - **Created `IsSummaryOwner` Permission Class:** 
    - Implemented a new permission class that checks whether the currently authenticated user is the owner of a specified lecture summary.
    - Validates the request based on the `summary_id` obtained from the URL.

- **Enhanced `api/tests/tests.py`:**
  - **Added `LectureSummaryByIdViewTest`:** 
    - Created tests to ensure the proper functionality of retrieving lecture summaries by ID.
    - **Test Cases:**  
      - `test_get_summary_by_id_successful`: Verifies that a valid summary ID returns a 200 OK response along with the correct summary data.
      - `test_get_summary_by_id_not_found`: Checks that a non-existent summary ID returns a 403 FORBIDDEN response.

- **Modified `api/views/session_views.py`:**
  - **Imported `IsSummaryOwner` Permission:** The new permission class was imported for use in the lecture summary views.
  - **Introduced `LectureSummaryByIdView`:**
    - Created a new view for retrieving a lecture summary using its unique summary ID.
    - Set the permission class to `IsSummaryOwner` to ensure only authorized users can access the summaries.
    - Defined an endpoint method to handle GET requests and return the corresponding lecture summary data.

- **Updated `hice_backend/urls.py`:**
  - **Added URL Path for Summary Retrieval:**
    - Defined a new URL route for the `LectureSummaryByIdView`, allowing clients to request lecture summaries by their ID using the path `/summary/<uuid:summary_id>/get-summary/`.