### PR TITLE
Enhance User POST Response with Redirect URL

### DIFF
--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -118,7 +118,12 @@ class SignUpInstructor(APIView):
             token, created = Token.objects.get_or_create(user=user)
             mailInstructor(user.email)  # Send a welcome email to the instructor
             return Response(
-                {"token": token.key, "user": str(user.id), "instructor": str(instructor.id)},
+                {
+                    "token": token.key,
+                    "user": str(user.id),
+                    "instructor": str(instructor.id),
+                    "redirect_url": "/",
+                },
                 status=status.HTTP_201_CREATED,
             )
         else:


### PR DESCRIPTION
This pull request introduces an enhancement to the user registration endpoint by adding a new field to the response payload. Below are the specific changes made:

- **Added a `redirect_url` to the response**:  
  - The API will now return a `redirect_url` field in the response when a user successfully registers or is created.  
  - This field is set to `/`, which can be used to redirect the user to the main page.

- **Code Adjustment**:  
  - The endpoint now constructs the response dictionary with the new `redirect_url`, alongside the existing `token`, `user`, and `instructor` fields.

### Impact:  
- This change enhances the user experience by providing a clear navigation path post-registration.
- The new structure allows for easier front-end handling of user responses upon successful registration.