### PR TITLE
Refactor URL endpoints for audio recordings in `urls.py`

### DIFF
--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -126,22 +126,11 @@ urlpatterns = [
         name="swagger-ui",
     ),
     path("check-developer/", CheckDeveloperStatus.as_view(), name="check-developer"),
-    path("upload-audio/", UploadAudioView.as_view(), name="upload-audio-will-be-deprecated"),
     path("recordings/upload-audio/", UploadAudioView.as_view(), name="upload-audio"),
-    path(
-        "instructor-recordings/<uuid:recording_id>/update-transcript/",
-        UpdateTranscriptView.as_view(),
-        name="update-transcript-will-be-deprecated",
-    ),
     path(
         "recordings/<uuid:recording_id>/update-transcript/",
         UpdateTranscriptView.as_view(),
         name="update-transcript",
-    ),
-    path(
-        "instructor-recordings/<uuid:recording_id>/delete-recording",
-        DeleteRecordingView.as_view(),
-        name="delete-recording-will-be-deprecated",
     ),
     path(
         "recordings/<uuid:recording_id>/delete-recording",
@@ -149,19 +138,9 @@ urlpatterns = [
         name="delete-recording",
     ),
     path(
-        "instructor-recordings/<uuid:recording_id>/update-duration/",
-        UpdateRecordingDurationView.as_view(),
-        name="update-recording-duration-will-be-deprecated",
-    ),
-    path(
         "recordings/<uuid:recording_id>/update-duration/",
         UpdateRecordingDurationView.as_view(),
         name="update-recording-duration",
-    ),
-    path(
-        "instructor-recordings/",
-        RecordingsView.as_view(),
-        name="instructor-recording-will-be-deprecated",
     ),
     path(
         "recordings/",
@@ -169,19 +148,9 @@ urlpatterns = [
         name="instructor-recording",
     ),
     path(
-        "instructor-recordings/<uuid:recording_id>/get-transcript/",
-        GetTranscriptView.as_view(),
-        name="get-transcript-will-be-deprecated",
-    ),
-    path(
         "recordings/<uuid:recording_id>/get-transcript/",
         GetTranscriptView.as_view(),
         name="get-transcript",
-    ),
-    path(
-        "instructor-recordings/<uuid:recording_id>/update-title/",
-        UpdateRecordingTitleView.as_view(),
-        name="recording-update-title-will-be-deprecated",
     ),
     path(
         "recordings/<uuid:recording_id>/update-title/",
@@ -196,11 +165,6 @@ urlpatterns = [
         "generate-temporary-credentials/",
         GenerateTemporaryCredentialsView.as_view(),
         name="generate-temporary-credentials",
-    ),
-    path(
-        "create-recording/",
-        CreateRecordingView.as_view(),
-        name="create-recording-will-be-deprecated",
     ),
     path(
         "recordings/create-recording/",


### PR DESCRIPTION
KAN-186

This pull request introduces several changes to the `urls.py` file in the `hice_backend` application. The key updates are focused on organizing and deprecating certain audio recording-related endpoints to provide a cleaner and more structured API. Below is a summary of the changes made:

## Changes Made:
- **Endpoint Updates:**
  - Replaced the old instructor-related endpoints with a more standardized `/recordings/` structure.
  - Removed the deprecated naming conventions for several audio recording routes, replacing them with shorter, more intuitive names.

- **Removed Deprecated Endpoints:**
  - Eliminated old instructor-specific endpoints that are no longer needed:
    - `upload-audio/` -> deprecated
    - `update-transcript/` -> deprecated
    - `delete-recording` -> deprecated
    - `update-duration/` -> deprecated
    - `instructor-recording/` -> deprecated
    - `get-transcript/` -> deprecated
    - `update-title/` -> deprecated
    - `create-recording/` -> deprecated

- **Updated Endpoint Structure:**
  - Introduced a unified pattern for recording endpoints, as follows:
    - `recordings/upload-audio/`
    - `recordings/<uuid:recording_id>/update-transcript/`
    - `recordings/<uuid:recording_id>/delete-recording/`
    - `recordings/<uuid:recording_id>/update-duration/`
    - `recordings/`
    - `recordings/<uuid:recording_id>/get-transcript/`
    - `recordings/<uuid:recording_id>/update-title/`
    - `recordings/create-recording/`

These changes aim to streamline the audio recording APIs, improve clarity, and facilitate easier maintenance in the future.