### PR TITLE
Enhance Lecture Summary Management with Update Functionality

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -8,6 +8,7 @@ from .models import (
     LectureSummary,
 )
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned, FieldError
+from django.shortcuts import get_object_or_404
 
 
 class AllowInstructor(permissions.BasePermission):
@@ -120,7 +121,7 @@ class IsSummaryOwner(permissions.BasePermission):
 
         try:
             # Retrieve the LectureSummary and verify the ownership of the recording
-            summary = LectureSummary.objects.get(id=summary_id)
+            summary = get_object_or_404(LectureSummary, id=summary_id)
         except (ObjectDoesNotExist, MultipleObjectsReturned, FieldError):
             return False
         return request.user == summary.recording.instructor.user

--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -766,12 +766,36 @@ class LectureSummaryByIdViewTest(BaseTest):
         url = reverse("get-summary", kwargs={"summary_id": non_existent_id})
         response = self.client_instructor.get(url, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_summary_by_id_forbidden(self):
         # non owner
         url = reverse("get-summary", kwargs={"summary_id": str(self.lecture_summary.id)})
         response = self.client_instructor_two.get(url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_update_summary_by_id(self):
+        data = {"summary": "This is a new summary"}
+        url = reverse("update-summary", kwargs={"summary_id": str(self.lecture_summary.id)})
+        response = self.client_instructor.patch(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["message"], "Summary updated successfully")
+        self.assertEqual(response.data["summary"], data["summary"])
+
+    def test_update_summary_by_id_not_found(self):
+        non_existent_id = "127ac01a-379b-44af-97e6-286bac44ff7f"
+        data = {"summary": "This is a new summary"}
+        url = reverse("update-summary", kwargs={"summary_id": non_existent_id})
+        response = self.client_instructor.patch(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_summary_by_id_forbidden(self):
+        data = {"summary": "This is a new summary"}
+        url = reverse("update-summary", kwargs={"summary_id": str(self.lecture_summary.id)})
+        response = self.client_instructor_two.patch(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 

--- a/api/views/session_views.py
+++ b/api/views/session_views.py
@@ -375,3 +375,24 @@ class LectureSummaryByIdView(APIView):
         summary = LectureSummary.objects.get(id=summary_id)
         serializer = LectureSummarySerializer(summary)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@extend_schema(tags=["Summaries"])
+class UpdateLectureSummaryView(APIView):
+    permission_classes = [IsSummaryOwner]
+
+    @extend_schema(
+        request=LectureSummarySerializer,
+        description="Endpoint to update the summary of a lecture given summary_id",
+    )
+    def patch(self, request, summary_id):
+        summary = LectureSummary.objects.get(id=summary_id)
+        serializer = LectureSummarySerializer(data=request.data)
+        if serializer.is_valid():
+            summary.summary = serializer.validated_data["summary"]
+            summary.save()
+            return Response(
+                {"message": "Summary updated successfully", "summary": summary.summary},
+                status=status.HTTP_200_OK,
+            )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -223,6 +223,11 @@ urlpatterns = [
         name="get-summary",
     ),
     path(
+        "summary/<uuid:summary_id>/update-summary/",
+        UpdateLectureSummaryView.as_view(),
+        name="update-summary",
+    ),
+    path(
         "token/verify/",
         TokenVerificationView.as_view(),
         name="verify-token",


### PR DESCRIPTION
This pull request introduces a new feature to update lecture summaries within the API. In addition to correcting permission checks, it enhances the existing capabilities for managing summaries.

### Key Changes:

1. **Update Lecture Summary API Endpoint**:
   - Added a new API endpoint for updating existing lecture summaries:
     - **Path**: `summary/<uuid:summary_id>/update-summary/`
     - **Method**: `PATCH`
     - Ensures that only the owner of the summary can perform updates.

2. **Use of `get_object_or_404`**:
   - Updated the ownership check in the permissions file to use `get_object_or_404()` instead of the direct `get()` method. This:
     - Reduces unnecessary error handling for objects that aren't found.
     - Simplifies the code and enhances readability.

3. **Unit Tests for Update Functionality**:
   - Implemented three new test cases to ensure the stability and correctness of the new update functionality:
     - **`test_update_summary_by_id`**: Confirms a successful summary update returns the correct status and message.
     - **`test_update_summary_by_id_not_found`**: Validates the response when trying to update a non-existent summary ID.
     - **`test_update_summary_by_id_forbidden`**: Ensures that attempts to update a summary by a non-owner return a forbidden status.

4. **Response Improvement**:
   - Updated the responses for non-existent summaries to return a 404 status code instead of 403, accurately reflecting the error type.
   - Improved response data for successful updates, returning both a success message and the updated summary content.

### Code Structure Changes:
- **`api/permissions.py`**:
   - Revised permission handling for summary retrieval and ownership verification.
- **`api/views/session_views.py`**:
   - Introduced `UpdateLectureSummaryView` which handles the logic for updating lecture summaries.
- **`api/tests/tests.py`**:
   - Added comprehensive tests covering various scenarios for the new update functionality.
- **`hice_backend/urls.py`**:
   - Registered the new update summary endpoint for routing within the application.

This PR aims to improve the management of lecture summaries and provide a better user experience while adhering to Django best practices.