### PR TITLE
Enhance Quiz Retrieval with Sorting and Testing Improvements

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -73,6 +73,9 @@ class Quiz(models.Model):
         InstructorRecordings, on_delete=models.CASCADE, null=True
     )
 
+    class Meta:
+        ordering = ["-created_at"]
+
     def to_json(self):
         return {
             "id": self.id,

--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-
+from datetime import timedelta
 from django.db import transaction
 from django.test import TestCase
 from django.urls import reverse
@@ -231,10 +231,16 @@ class CreateQuizViewTest(BaseTest):
 
 class InstructorQuizzesViewTest(BaseTest):
     def test_get_quizzes(self):
+        quiz2 = Quiz.objects.create(title="Test Quiz newest", instructor=self.instructor)
+        quiz2.created_at = self.new_quiz.created_at + timedelta(days=1)
+        quiz2.save()
+
         url = reverse("instructor-quizzes")
         instructor_response = self.client_instructor.get(url)
 
         self.assertEqual(instructor_response.status_code, 200)
+        self.assertEqual(instructor_response.data["quizzes"][0]["title"], "Test Quiz newest")
+        self.assertEqual(instructor_response.data["quizzes"][1]["title"], "Test Quiz")
 
 
 class QuestionViewTest(BaseTest):

--- a/api/views/quiz_views.py
+++ b/api/views/quiz_views.py
@@ -96,7 +96,7 @@ class InstructorQuizzesView(APIView):
 
     @extend_schema(responses={200: QuizListSerializer}, summary="Get all quizzes by instructor")
     def get(self, request):
-        quizzes = Quiz.objects.filter(instructor=request.user.instructor).order_by("-created_at")
+        quizzes = Quiz.objects.filter(instructor=request.user.instructor)
         return Response(QuizListSerializer({"quizzes": quizzes}).data, status=status.HTTP_200_OK)
 
 

--- a/api/views/quiz_views.py
+++ b/api/views/quiz_views.py
@@ -96,7 +96,7 @@ class InstructorQuizzesView(APIView):
 
     @extend_schema(responses={200: QuizListSerializer}, summary="Get all quizzes by instructor")
     def get(self, request):
-        quizzes = Quiz.objects.filter(instructor=request.user.instructor)
+        quizzes = Quiz.objects.filter(instructor=request.user.instructor).order_by("-created_at")
         return Response(QuizListSerializer({"quizzes": quizzes}).data, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
KAN-208: Ensure the /instructor/quizzes/ API retrieves quizzes in chronological order. 

This pull request includes key updates to the quiz retrieval functionality and related unit tests. The following changes have been made:

- **Sorting of Quizzes**:
  - Updated the query in the `InstructorQuizzesView` to return quizzes sorted by the `created_at` field in descending order. This ensures that the most recently created quizzes appear first in the response.

  - **Code Change**:
    ```python
    quizzes = Quiz.objects.filter(instructor=request.user.instructor).order_by("-created_at")
    ```

- **Unit Test Enhancements**:
  - Introduced a new quiz for testing purposes within the `InstructorQuizzesViewTest` class. The new quiz titled "Test Quiz newest" is created with a `created_at` timestamp set to one day after an existing quiz, allowing for effective testing of quiz retrieval order.

  - **Assertions Added**:
    - Validated that the first quiz returned in the instructor's response is indeed "Test Quiz newest".
    - Verified that the second quiz returned is the original "Test Quiz".

  - **Code Changes**:
    ```python
    quiz2 = Quiz.objects.create(title="Test Quiz newest", instructor=self.instructor)
    quiz2.created_at = self.new_quiz.created_at + timedelta(days=1)
    quiz2.save()
    
    self.assertEqual(instructor_response.data["quizzes"][0]["title"], "Test Quiz newest")
    self.assertEqual(instructor_response.data["quizzes"][1]["title"], "Test Quiz")
    ```

These changes enhance the usability and reliability of the quiz API endpoints, ensuring that instructors can view their quizzes in a logical and expected order.