### PR TITLE
KAN-224: Add Summaries and Quizzes Chronologically API Endpoint

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -249,8 +249,3 @@ class LectureSummarySerializer(serializers.ModelSerializer):
         model = LectureSummary
         fields = ["id", "summary", "recording_id", "created_at"]
         read_only_fields = ["id", "recording_id", "created_at"]
-
-
-class SummariesQuizzesChronologicalSerializer(serializers.ModelSerializer):
-    class Meta:
-        pass

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -324,10 +324,10 @@ class QuizTypedSerializer(QuizSerializer):
 
 class QuizAndSummarySerializer(serializers.Serializer):
     def to_representation(self, instance):
-        print(instance)
         if isinstance(instance, Quiz):
             return QuizTypedSerializer(instance).data
         elif isinstance(instance, LectureSummary):
             return LectureSummaryTypedSerializer(instance).data
         else:
-            print("Skipping")
+            # TODO: Add a logging statement once logging is configured
+            pass

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -252,5 +252,14 @@ class LectureSummarySerializer(serializers.ModelSerializer):
 
 
 class GetQuizzesAndSummariesSerializer(serializers.Serializer):
-    lecture_summaries = LectureSummarySerializer(many=True)
-    quizzes = QuizSerializer(many=True)
+    def to_representation(self, instance):
+        if isinstance(instance, Quiz):
+            res = QuizSerializer(instance).data
+            res["type"] = "quiz"
+            return res
+        elif isinstance(instance, LectureSummary):
+            res = LectureSummarySerializer(instance).data
+            res["type"] = "summary"
+            return res
+        else:
+            return {}

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -249,3 +249,8 @@ class LectureSummarySerializer(serializers.ModelSerializer):
         model = LectureSummary
         fields = ["id", "summary", "recording_id", "created_at"]
         read_only_fields = ["id", "recording_id", "created_at"]
+
+
+class SummariesQuizzesChronologicalSerializer(serializers.ModelSerializer):
+    class Meta:
+        pass

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -251,24 +251,6 @@ class LectureSummarySerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "recording_id", "created_at"]
 
 
-class GetQuizzesAndSummariesSerializer(serializers.Serializer):
-    def to_representation(self, instance):
-        data = []
-        for entry in instance:
-            if isinstance(entry, Quiz):
-                res = QuizSerializer(entry).data
-                res["type"] = "quiz"
-                data.append(res)
-            elif isinstance(entry, LectureSummary):
-                res = LectureSummarySerializer(entry).data
-                res["type"] = "summary"
-                data.append(res)
-            else:
-                print("Skipping")
-
-        return data
-
-
 class LectureSummaryTypedSerializer(LectureSummarySerializer):
     type = serializers.CharField(required=True, allow_blank=False)
 
@@ -283,3 +265,14 @@ class QuizTypedSerializer(QuizSerializer):
     class Meta:
         model = Quiz
         fields = "__all__"
+
+
+class QuizAndSummarySerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        print(instance)
+        if isinstance(instance, Quiz):
+            return QuizTypedSerializer(instance).data
+        elif isinstance(instance, LectureSummary):
+            return LectureSummaryTypedSerializer(instance).data
+        else:
+            print("Skipping")

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -253,13 +253,33 @@ class LectureSummarySerializer(serializers.ModelSerializer):
 
 class GetQuizzesAndSummariesSerializer(serializers.Serializer):
     def to_representation(self, instance):
-        if isinstance(instance, Quiz):
-            res = QuizSerializer(instance).data
-            res["type"] = "quiz"
-            return res
-        elif isinstance(instance, LectureSummary):
-            res = LectureSummarySerializer(instance).data
-            res["type"] = "summary"
-            return res
-        else:
-            return {}
+        data = []
+        for entry in instance:
+            if isinstance(entry, Quiz):
+                res = QuizSerializer(entry).data
+                res["type"] = "quiz"
+                data.append(res)
+            elif isinstance(entry, LectureSummary):
+                res = LectureSummarySerializer(entry).data
+                res["type"] = "summary"
+                data.append(res)
+            else:
+                print("Skipping")
+
+        return data
+
+
+class LectureSummaryTypedSerializer(LectureSummarySerializer):
+    type = serializers.CharField(required=True, allow_blank=False)
+
+    class Meta:
+        model = LectureSummary
+        fields = "__all__"
+
+
+class QuizTypedSerializer(QuizSerializer):
+    type = serializers.CharField(required=True, allow_blank=False)
+
+    class Meta:
+        model = Quiz
+        fields = "__all__"

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -254,3 +254,19 @@ class LectureSummarySerializer(serializers.ModelSerializer):
 class GetQuizzesAndSummariesSerializer(serializers.Serializer):
     lecture_summaries = LectureSummarySerializer(many=True)
     quizzes = QuizSerializer(many=True)
+
+    def to_representation(self, instance):
+        summaries = LectureSummarySerializer(instance.lecture_summaries, many=True)
+        quizzes = QuizSerializer(instance.quizzes, many=True)
+
+        json_data = []
+
+        for summary in summaries:
+            json_data.append({"type": "summary", **summary})
+
+        for quiz in quizzes:
+            json_data.append({"type": "quiz", **quiz})
+
+        json_data.sort(key=lambda item: item["created_at"])
+
+        return json_data

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -249,3 +249,8 @@ class LectureSummarySerializer(serializers.ModelSerializer):
         model = LectureSummary
         fields = ["id", "summary", "recording_id", "created_at"]
         read_only_fields = ["id", "recording_id", "created_at"]
+
+
+class GetQuizzesAndSummariesSerializer(serializers.Serializer):
+    lecture_summaries = LectureSummarySerializer(many=True)
+    quizzes = QuizSerializer(many=True)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -254,19 +254,3 @@ class LectureSummarySerializer(serializers.ModelSerializer):
 class GetQuizzesAndSummariesSerializer(serializers.Serializer):
     lecture_summaries = LectureSummarySerializer(many=True)
     quizzes = QuizSerializer(many=True)
-
-    def to_representation(self, instance):
-        summaries = LectureSummarySerializer(instance.lecture_summaries, many=True)
-        quizzes = QuizSerializer(instance.quizzes, many=True)
-
-        json_data = []
-
-        for summary in summaries:
-            json_data.append({"type": "summary", **summary})
-
-        for quiz in quizzes:
-            json_data.append({"type": "quiz", **quiz})
-
-        json_data.sort(key=lambda item: item["created_at"])
-
-        return json_data

--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -1018,7 +1018,7 @@ class GetQuizzesAndSummariesTests(BaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertIn("quizzes", response_data)
-        self.assertIn("summaries", response_data)
+        self.assertIn("lecture_summaries", response_data)
 
     def test_get_summaries_quizzes_forbidden(self):
         response = self.client_instructor_two.get(self.url, format="json")

--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -993,3 +993,23 @@ class UserAuthTests(BaseTest):
     def test_logout_without_token(self):
         response = self.client.post(self.logout_url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class SummariesQuizzesChronologicallyTests(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.recording = InstructorRecordings.objects.create(instructor=self.instructor)
+        self.summary = LectureSummary.objects.create(recording_id=self.recording.id)
+        self.url = reverse("get-quizzes-and-summaries", kwargs={"recording_id": self.recording.id})
+
+    def test_get_summaries_quizzes_successfully(self):
+        response = self.client_instructor.get(self.url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_summaries_quizzes_forbidden(self):
+        response = self.client_instructor_two.get(self.url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_summaries_quizzes_unauthorized(self):
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/api/views/recordings_views.py
+++ b/api/views/recordings_views.py
@@ -227,6 +227,5 @@ class GetQuizzesAndSummaries(APIView):
         )
 
         data = sorted(chain(quizzes, summaries), key=lambda obj: obj.created_at, reverse=True)
-        print(data)
         serializer = QuizAndSummarySerializer(data, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -758,6 +758,19 @@ class QuizByRecordingView(APIView):
 class SummariesAndQuizzesChronologically(APIView):
     permission_classes = [IsRecordingOwner]
 
+    @extend_schema(
+        operation_id="get-quizzes-and-summaries",
+        summary="Get quizzes and summaries in chronological order.",
+        description="Returns all quizzes and summaries associated with a specific recording ID.",
+        responses={
+            200: OpenApiTypes.OBJECT,
+            403: OpenApiTypes.OBJECT,
+            404: OpenApiTypes.OBJECT,
+        },
+    )
+    def get(self, request, recording_id):
+        pass
+
 
 class TokenVerificationView(APIView):
     permission_classes = [IsAuthenticated]

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -754,6 +754,11 @@ class QuizByRecordingView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
+@extend_schema(tags=["Recordings"])
+class SummariesAndQuizzesChronologically(APIView):
+    permission_classes = [IsRecordingOwner]
+
+
 class TokenVerificationView(APIView):
     permission_classes = [IsAuthenticated]
     throttle_classes = [UserRateThrottle]

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -757,7 +757,7 @@ class QuizByRecordingView(APIView):
 
 
 @extend_schema(tags=["Recordings"])
-class SummariesAndQuizzesChronologically(APIView):
+class GetQuizzesAndSummaries(APIView):
     permission_classes = [IsRecordingOwner]
 
     @extend_schema(

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -38,7 +38,7 @@ from api.serializers import (
     SignUpInstructorSerializer,
     ContactMessageSerializer,
     QuizSerializer,
-    LectureSummarySerializer,
+    GetQuizzesAndSummariesSerializer,
 )
 from drf_spectacular.utils import extend_schema, OpenApiExample, inline_serializer
 from drf_spectacular.types import OpenApiTypes
@@ -762,13 +762,11 @@ class GetQuizzesAndSummaries(APIView):
 
     @extend_schema(
         operation_id="get-quizzes-and-summaries",
+        request=GetQuizzesAndSummariesSerializer,
         summary="Get quizzes and summaries in chronological order.",
         description="Returns all quizzes and summaries associated with a specific recording ID.",
         responses={
-            200: inline_serializer(
-                "Quizzes and Summaries",
-                {"quiz": QuizSerializer(many=True), "summary": LectureSummarySerializer(many=True)},
-            ),
+            200: GetQuizzesAndSummariesSerializer(many=True),
             401: inline_serializer("detail_response", {"detail": serializers.CharField()}),
             403: inline_serializer("detail_response", {"detail": serializers.CharField()}),
         },
@@ -778,13 +776,10 @@ class GetQuizzesAndSummaries(APIView):
         quizzes = Quiz.objects.filter(instructor_recording_id=recording_id).order_by("created_at")
         summaries = LectureSummary.objects.filter(recording_id=recording_id).order_by("created_at")
 
-        quizzes_serializer = QuizSerializer(quizzes, many=True)
-        summaries_serializer = LectureSummarySerializer(summaries, many=True)
+        data = {"quizzes": quizzes, "lecture_summaries": summaries}
 
-        return Response(
-            {"quizzes": quizzes_serializer.data, "summaries": summaries_serializer.data},
-            status=status.HTTP_200_OK,
-        )
+        serializer = GetQuizzesAndSummariesSerializer(data)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class TokenVerificationView(APIView):

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -128,6 +128,11 @@ urlpatterns = [
     path("check-developer/", CheckDeveloperStatus.as_view(), name="check-developer"),
     path("recordings/upload-audio/", UploadAudioView.as_view(), name="upload-audio"),
     path(
+        "recordings/<uuid:recording_id>/get-quizzes-and-summaries",
+        SummariesAndQuizzesChronologically.as_view(),
+        name="get-quizzes-and-summaries",
+    ),
+    path(
         "recordings/<uuid:recording_id>/update-transcript/",
         UpdateTranscriptView.as_view(),
         name="update-transcript",

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -129,7 +129,7 @@ urlpatterns = [
     path("recordings/upload-audio/", UploadAudioView.as_view(), name="upload-audio"),
     path(
         "recordings/<uuid:recording_id>/get-quizzes-and-summaries",
-        SummariesAndQuizzesChronologically.as_view(),
+        GetQuizzesAndSummaries.as_view(),
         name="get-quizzes-and-summaries",
     ),
     path(


### PR DESCRIPTION
KAN-224

This pull request introduces a new API endpoint that allows instructors to retrieve quizzes and summaries in chronological order for a specific recording ID. Here are the detailed changes made:

- **New API View**: Added `GetQuizzesAndSummaries` class to handle GET requests for quizzes and summaries.
  - **View Functionality**: The view checks for the user's permission and retrieves quizzes and summaries associated with a specific recording ID.
  - **Response Structure**: Returns a JSON object containing lists of quizzes and summaries sorted by creation date.
- **New URL Route**: Created a new route in `urls.py` to map the recording ID to the newly created API view.
  - **Endpoint**: `recordings/<uuid:recording_id>/get-quizzes-and-summaries`
- **Permission Handling**: Implemented permission checking using the `IsRecordingOwner` permission class to restrict access to the owner of the recording.
- **Tests Implementation**: Added a series of tests under `GetQuizzesAndSummaries` to ensure the expected behavior of the new endpoint:
  - **Successful Retrieval**: Test to verify that an instructor can successfully retrieve summaries and quizzes.
  - **Forbidden Access**: Test to check access restrictions for a non-owner instructor.
  - **Unauthorized Access**: Test to confirm that unauthorized users receive a 401 response.
- **Response Serialization**: Incorporated `LectureSummarySerializer` into the project to facilitate serialization of summaries in the response structure.
- **Inline Schema Documentation**: Enhanced OpenAPI schema documentation for the new endpoint to include response descriptions and structure.