### PR TITLE
feat: Add Quiz Session Log Functionality

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -159,6 +159,12 @@ class AddQuizSessionLogSerializer(serializers.Serializer):
     question_multiple_choice_id = serializers.UUIDField(required=False)
     action = serializers.CharField(required=True)
 
+    id = serializers.UUIDField(read_only=True)
+    created_at = serializers.DateTimeField(read_only=True)
+    quiz_session = serializers.PrimaryKeyRelatedField(read_only=True)
+    quiz_session_student = serializers.PrimaryKeyRelatedField(read_only=True)
+    question_multiple_choice = serializers.PrimaryKeyRelatedField(read_only=True)
+
     def validate_action(self, value):
         allowed_actions = ["connected", "disconnected", "reconnected"]
         if value not in allowed_actions:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -153,20 +153,11 @@ class QuizTitleUpdateSerializer(serializers.Serializer):
     title = serializers.CharField(required=True, allow_blank=False)
 
 
-class AddQuizSessionLogSerializer(serializers.ModelSerializer):
+class AddQuizSessionLogSerializer(serializers.Serializer):
     quiz_session_code = serializers.CharField(required=True, allow_blank=False)
     quiz_session_student_id = serializers.IntegerField(required=True, min_value=0)
     question_multiple_choice_id = serializers.UUIDField(required=False)
     action = serializers.CharField(required=True)
-
-    class Meta:
-        model = QuizSessionLog
-        fields = [
-            "quiz_session_code",
-            "quiz_session_student_id",
-            "question_multiple_choice_id",
-            "action",
-        ]
 
     def validate_action(self, value):
         allowed_actions = ["connected", "disconnected", "reconnected"]
@@ -204,7 +195,6 @@ class AddQuizSessionLogSerializer(serializers.ModelSerializer):
         return data
 
     def create(self, validated_data):
-        validated_data.pop("quiz_session_code")
         validated_data.pop("quiz_session_student_id")
         validated_data.pop("question_multiple_choice_id", None)
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -14,6 +14,7 @@ from .models import (
     Settings,
     ContactMessage,
     LectureSummary,
+    QuizSessionLog,
 )
 
 
@@ -150,6 +151,64 @@ class QuizListSerializer(serializers.Serializer):
 
 class QuizTitleUpdateSerializer(serializers.Serializer):
     title = serializers.CharField(required=True, allow_blank=False)
+
+
+class AddQuizSessionLogSerializer(serializers.ModelSerializer):
+    quiz_session_code = serializers.CharField(required=True, allow_blank=False)
+    quiz_session_student_id = serializers.IntegerField(required=True, min_value=0)
+    question_multiple_choice_id = serializers.UUIDField(required=False)
+    action = serializers.CharField(required=True)
+
+    class Meta:
+        model = QuizSessionLog
+        fields = [
+            "quiz_session_code",
+            "quiz_session_student_id",
+            "question_multiple_choice_id",
+            "action",
+        ]
+
+    def validate_action(self, value):
+        allowed_actions = ["connected", "disconnected", "reconnected"]
+        if value not in allowed_actions:
+            raise serializers.ValidationError("Invalid action")
+        return value
+
+    def validate(self, data):
+        # resolve objects
+        try:
+            data["quiz_session"] = QuizSession.objects.get(code=data["quiz_session_code"])
+        except QuizSession.DoesNotExist:
+            raise serializers.ValidationError({"quiz_session_code": "Quiz session not found."})
+
+        try:
+            data["quiz_session_student"] = QuizSessionStudent.objects.get(
+                id=data["quiz_session_student_id"]
+            )
+        except QuizSessionStudent.DoesNotExist:
+            raise serializers.ValidationError({"quiz_session_student_id": "Student not found."})
+
+        question_multiple_choice_id = data.get("question_multiple_choice_id")
+        if question_multiple_choice_id:
+            try:
+                data["question_multiple_choice"] = QuestionMultipleChoice.objects.get(
+                    id=question_multiple_choice_id
+                )
+            except QuestionMultipleChoice.DoesNotExist:
+                raise serializers.ValidationError(
+                    {"question_multiple_choice_id": "Question not found."}
+                )
+        else:
+            data["question_multiple_choice"] = None
+
+        return data
+
+    def create(self, validated_data):
+        validated_data.pop("quiz_session_code")
+        validated_data.pop("quiz_session_student_id")
+        validated_data.pop("question_multiple_choice_id", None)
+
+        return QuizSessionLog.objects.create(**validated_data)
 
 
 class RecordingTitleUpdateSerializer(serializers.Serializer):

--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -404,6 +404,70 @@ class QuizSessionsByInstructorViewTest(TestCase):
         self.assertIn(self.quiz.title, str(response.content))
 
 
+class AddQuizSessionLogTest(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.valid_payload = {
+            "quiz_session_code": self.new_quiz_session.code,
+            "quiz_session_student_id": self.new_quiz_session_student.id,
+            "question_multiple_choice_id": self.new_question.id,
+            "action": "connected",
+        }
+
+        self.invalid_code_payload = {
+            "quiz_session_code": "INVALID CODE",
+            "quiz_session_student_id": self.new_quiz_session_student.id,
+            "action": "connected",
+        }
+
+        self.invalid_student_payload = {
+            "quiz_session_code": self.new_quiz_session.code,
+            "quiz_session_student_id": 999,
+            "action": "connected",
+        }
+
+        self.invalid_question_payload = {
+            "quiz_session_code": self.new_quiz_session.code,
+            "quiz_session_student_id": self.new_quiz_session_student.id,
+            "question_multiple_choice_id": 999,
+            "action": "connected",
+        }
+
+        self.invalid_action_payload = {
+            "quiz_session_code": self.new_quiz_session.code,
+            "quiz_session_student_id": self.new_quiz_session_student.id,
+            "action": "Invalid Option",
+        }
+
+        self.url = reverse("add-quiz-session-log")
+
+    def test_create_log_entry_success(self):
+        response = self.client.post(self.url, self.valid_payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["message"], "Log entry successfully created.")
+        self.assertEqual(QuizSessionLog.objects.count(), 1)
+
+    def test_create_log_entry_invalid_code(self):
+        response = self.client.post(self.url, self.invalid_code_payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.assertEqual(response.data, "Quiz session not found.")
+
+    def test_create_log_entry_invalid_student(self):
+        response = self.client.post(self.url, self.invalid_student_payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data, "Student not found.")
+
+    def test_create_log_entry_invalid_question(self):
+        response = self.client.post(self.url, self.invalid_question_payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data, "Question not found.")
+
+    def test_create_log_entry_invalid_action(self):
+        response = self.client.post(self.url, self.invalid_action_payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
 class LoginViewTest(BaseTest):
 
     def test_post_login(self):

--- a/api/tests/tests.py
+++ b/api/tests/tests.py
@@ -443,8 +443,13 @@ class AddQuizSessionLogTest(BaseTest):
 
     def test_create_log_entry_success(self):
         response = self.client.post(self.url, self.valid_payload, format="json")
+        self.assertEqual(response.data["quiz_session_code"], self.new_quiz_session.code)
+        self.assertEqual(response.data["quiz_session_student_id"], self.new_quiz_session_student.id)
+        self.assertEqual(response.data["question_multiple_choice_id"], str(self.new_question.id))
+        self.assertEqual(response.data["action"], "connected")
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["message"], "Log entry successfully created.")
+
         self.assertEqual(QuizSessionLog.objects.count(), 1)
 
     def test_create_log_entry_invalid_code(self):

--- a/api/views/session_views.py
+++ b/api/views/session_views.py
@@ -8,7 +8,7 @@ from api.models import (
     UserResponse,
     QuestionMultipleChoice,
     InstructorRecordings,
-    LectureSummary
+    LectureSummary,
 )
 from django.shortcuts import get_object_or_404
 from rest_framework.permissions import AllowAny

--- a/api/views/session_views.py
+++ b/api/views/session_views.py
@@ -8,8 +8,7 @@ from api.models import (
     UserResponse,
     QuestionMultipleChoice,
     InstructorRecordings,
-    LectureSummary,
-    QuizSessionLog,
+    LectureSummary
 )
 from django.shortcuts import get_object_or_404
 from rest_framework.permissions import AllowAny

--- a/api/views/session_views.py
+++ b/api/views/session_views.py
@@ -235,7 +235,7 @@ class QuizSessionLogView(APIView):
     @extend_schema(
         request=AddQuizSessionLogSerializer(),
         responses={
-            201: OpenApiResponse(description="Log created and added successfully"),
+            201: AddQuizSessionLogSerializer,
             400: OpenApiResponse(description="Bad Request"),
             404: OpenApiResponse(description="Object not found"),
         },

--- a/api/views/session_views.py
+++ b/api/views/session_views.py
@@ -244,9 +244,7 @@ class QuizSessionLogView(APIView):
         serializer = AddQuizSessionLogSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
-            return Response(
-                {"message": "Log entry successfully created."}, status=status.HTTP_201_CREATED
-            )
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
 
         if "quiz_session_code" in serializer.errors:
             return Response("Quiz session not found.", status=status.HTTP_404_NOT_FOUND)

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -48,6 +48,11 @@ urlpatterns = [
     path("logout/", Logout.as_view(), name="logout"),
     path("quiz-session/", QuizSessionView.as_view(), name="quiz-session-list"),
     path(
+        "quiz-session/add-log-entry/",
+        QuizSessionLogView.as_view(),
+        name="add-quiz-session-log",
+    ),
+    path(
         "quiz-session/<str:code>/",
         QuizSessionStudentView.as_view(),
         name="quiz-session-detail",


### PR DESCRIPTION
KAN-211: Implement Unprotected API Endpoint to Log Quiz Session Activities

This PR introduces the `AddQuizSessionLogSerializer` and a new API endpoint for logging quiz session activities. The changes include serializer validations and associated test cases to ensure robust functionality.

### Changes Made:

- **New Serializer**: Added `AddQuizSessionLogSerializer` which includes fields for logging quiz session data:
  - `quiz_session_code`: Required field.
  - `quiz_session_student_id`: Required field, must be a non-negative integer.
  - `question_multiple_choice_id`: Optional UUID field.
  - `action`: Required field for indicating the session status, validated against a predefined list of actions (`connected`, `disconnected`, `reconnected`).

- **Validation Logic**: Implemented validation methods within the serializer:
  - `validate_action`: Checks if the action is valid.
  - `validate`: Resolves associated objects (quiz session, student, question) and raises errors if any are not found.

- **Create Method**: Overrides the `create` method in the serializer to log actions while excluding unnecessary fields from the created object.

- **New API View**: Created `QuizSessionLogView` to handle the POST requests for logging sessions.
  - Utilizes the `AddQuizSessionLogSerializer` to handle incoming data.
  - Returns appropriate HTTP responses based on the outcome (201 for success, 400 for bad request, 404 for not found).

- **API Endpoint**: Added routing for the new log entry functionality:
  - Endpoint: `POST /quiz-session/add-log-entry/`

- **Test Case Suite**: Developed unit tests to ensure API functionality and robustness:
  - Valid log entry creation.
  - Handling of invalid quiz codes, student IDs, question IDs, and actions.

### Additional Notes:
- This implementation ensures a consistent and validated logging mechanism for quiz sessions, enhancing data integrity and making it easier to track user actions.