### PR TITLE
Add JWT Authentication Support

### DIFF
--- a/.github/workflows/websocket-tests.yml
+++ b/.github/workflows/websocket-tests.yml
@@ -30,6 +30,6 @@ jobs:
     - name: Run WebSocket Tests
       env:
         DJANGO_SETTINGS_MODULE: hice_backend.settings
-        SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+        DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
       run: |
         pytest api/tests/consumer_tests.py -v

--- a/hice_backend/settings.py
+++ b/hice_backend/settings.py
@@ -3,6 +3,7 @@ import os
 import sys
 from pathlib import Path
 import boto3
+from datetime import timedelta
 
 load_dotenv()
 
@@ -39,6 +40,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "drf_spectacular",
     "channels",
+    "rest_framework_simplejwt",
 ]
 
 MIDDLEWARE = [
@@ -202,6 +204,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.TokenAuthentication",
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
 }
 
@@ -294,3 +297,14 @@ AWS_LAMBDA_INVOKER_SECRET_ACCESS_KEY = os.getenv("AWS_LAMBDA_INVOKER_SECRET_ACCE
 AWS_LAMBDA_INVOKER_REGION_NAME = os.getenv("AWS_LAMBDA_INVOKER_REGION_NAME", default="us-east-1")
 
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(
+        seconds=int(os.getenv("ACCESS_TOKEN_LIFETIME", default=3600))
+    ),
+    "REFRESH_TOKEN_LIFETIME": timedelta(
+        seconds=int(os.getenv("REFRESH_TOKEN_LIFETIME", default=86400))
+    ),
+    "SIGNING_KEY": SECRET_KEY,
+    "AUTH_HEADER_TYPES": ("Token",),
+}

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -6,6 +6,11 @@ from api.views.session_views import *
 from api.views.user_views import *
 from api.views.recordings_views import *
 from api.consumers import *
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+    TokenVerifyView,
+)
 
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
@@ -205,4 +210,7 @@ urlpatterns = [
         TokenVerificationView.as_view(),
         name="verify-token",
     ),
+    path("jwt-token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("jwt-token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("jwt-token/verify/", TokenVerifyView.as_view(), name="token_verify"),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,3 +72,4 @@ uritemplate==4.1.1
 urllib3==1.26.20
 watchtower==3.3.1
 zope.interface==6.4.post2
+djangorestframework-simplejwt==5.3.1


### PR DESCRIPTION
KAN-246
This pull request introduces JSON Web Token (JWT) authentication to the backend, enhancing security and user session management. Key changes include modifications to the `settings.py`, `urls.py`, and the addition of required packages in `requirements.txt`. Below are the details of the changes made:

## Changes Made:

- **Updated `settings.py`:**  
  - Imported `timedelta` from `datetime` to handle token lifetime configurations.
  - Added `rest_framework_simplejwt` to the `INSTALLED_APPS` list for JWT functionality.
  - Included `JWTAuthentication` in the `DEFAULT_AUTHENTICATION_CLASSES` setting, enabling JWT-based authentication.
  - Configured `SIMPLE_JWT` settings to define token lifetimes for access and refresh tokens:
    - `ACCESS_TOKEN_LIFETIME` is set using an environment variable with a default of 3600 seconds (1 hour).
    - `REFRESH_TOKEN_LIFETIME` is set using an environment variable with a default of 86400 seconds (24 hours).
    - `SIGNING_KEY` is set to use the existing `SECRET_KEY`.
    - `AUTH_HEADER_TYPES` is defined to include `Token` as a valid authentication header type.

- **Updated `urls.py`:**  
  - Imported three views from `rest_framework_simplejwt.views`:
    - `TokenObtainPairView` for obtaining a JWT pair.
    - `TokenRefreshView` for refreshing a JWT.
    - `TokenVerifyView` for verifying a JWT.
  - Added new URL patterns for JWT token management:
    - `jwt-token/` for token obtaining.
    - `jwt-token/refresh/` for refreshing the tokens.
    - `jwt-token/verify/` for verifying the tokens.

- **Updated `requirements.txt`:**  
  - Included `djangorestframework-simplejwt==5.3.1` to the dependencies to provide the necessary JWT functionality.

These changes collectively enable enhanced authentication mechanisms, offering better security and handling of user sessions.