### PR TITLE
🔒 Enhanced JWT Token Management with Blacklisting Support

### DIFF
--- a/hice_backend/settings.py
+++ b/hice_backend/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "channels",
     "rest_framework_simplejwt",
+    "rest_framework_simplejwt.token_blacklist",
 ]
 
 MIDDLEWARE = [
@@ -305,6 +306,8 @@ SIMPLE_JWT = {
     "REFRESH_TOKEN_LIFETIME": timedelta(
         seconds=int(os.getenv("REFRESH_TOKEN_LIFETIME", default=86400))
     ),
+    "ROTATE_REFRESH_TOKENS": True,
+    "BLACKLIST_AFTER_ROTATION": True,
     "SIGNING_KEY": SECRET_KEY,
     "AUTH_HEADER_TYPES": ("Token",),
 }

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -10,6 +10,7 @@ from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
     TokenVerifyView,
+    TokenBlacklistView,
 )
 
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
@@ -213,4 +214,5 @@ urlpatterns = [
     path("jwt-token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("jwt-token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("jwt-token/verify/", TokenVerifyView.as_view(), name="token_verify"),
+    path("jwt-token/blacklist/", TokenBlacklistView.as_view(), name="token_blacklist"),
 ]


### PR DESCRIPTION
KAN-247
This Pull Request introduces support for token blacklisting in our application, enhancing security measures for JWT tokens. The following changes have been made:

- **Added TokenBlacklistView**: The `TokenBlacklistView` has been imported and included in the URL routing to handle token blacklisting requests effectively.
- **Updated JWT Settings**: The JWT configuration in the settings has been enriched with the following options:
  - `ROTATE_REFRESH_TOKENS`: Set to `True` to ensure refresh tokens are rotated on each refresh, enhancing security by minimizing the risk of token misuse.
  - `BLACKLIST_AFTER_ROTATION`: Set to `True`, enabling blacklisting of the old refresh token after a new one is issued, ensuring that only the latest refresh token is valid.
- **Included `rest_framework_simplejwt.token_blacklist`**: The token blacklist app has been added to the Django settings to leverage the built-in functionalities for managing blacklisted tokens.

These updates are intended to improve the security framework of our application by controlling access through token blacklisting, ensuring a more robust authentication system.