### PR TITLE
Implement JWT Sign-Up Endpoint for Instructors

### DIFF
--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -858,9 +858,11 @@ class GoogleLogin(APIView):
 
 class JWTGoogleLogin(APIView):
     permission_classes = [AllowAny]
+    serializer_class = GoogleLoginRequestSerializer
 
     @extend_schema(
         tags=["Authentication Endpoint"],
+        request=GoogleLoginRequestSerializer
     )
     def post(self, request):
         token = request.data.get("token")

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -150,49 +150,6 @@ class SignUpInstructor(APIView):
 class JWTSignUpInstructor(APIView):
     permission_classes = [AllowAny]
 
-    @extend_schema(
-        operation_id="sign_up_instructor",
-        summary="Sign up as an Instructor",
-        description="Allows a new user to sign up as an instructor by "
-        "providing first name, last name (optional), email, and password.",
-        request=SignUpInstructorSerializer,
-        responses={
-            201: {
-                "description": "Instructor created successfully.",
-                "content": {
-                    "application/json": {
-                        "example": {
-                            "access": "abc123def456ghi789",
-                            "refresh": "abc123def456ghi789",
-                            "user": "user-uuid-string",
-                            "instructor": "instructor-uuid-string",
-                        }
-                    }
-                },
-            },
-            400: {
-                "description": "Bad Request. Input data is invalid.",
-                "content": {
-                    "application/json": {
-                        "example": {"message": "A user with this email already exists."}
-                    }
-                },
-            },
-        },
-        examples=[
-            OpenApiExample(
-                "Valid Input",
-                value={
-                    "first_name": "John",
-                    "last_name": "Doe",
-                    "email": "john.doe@example.com",
-                    "password": "StrongPassword123!",
-                },
-                request_only=True,
-                response_only=False,
-            ),
-        ],
-    )
     def post(self, request):
         serializer = SignUpInstructorSerializer(data=request.data)
         if serializer.is_valid():
@@ -315,46 +272,6 @@ class JWTLoginView(APIView):
     serializer_class = LoginSerializer
     permission_classes = [AllowAny]
 
-    @extend_schema(
-        operation_id="jwt_login",
-        summary="Login with JWT",
-        description="Allows a user to log in using email and password, and returns JWT tokens.",
-        request=LoginSerializer,
-        responses={
-            200: {
-                "description": "Login successful",
-                "content": {
-                    "application/json": {
-                        "example": {
-                            "access": "abc123def456ghi789",
-                            "refresh": "abc123def456ghi789",
-                            "user": "user-uuid-string",
-                            "instructor": "instructor-uuid-string",
-                        }
-                    }
-                },
-            },
-            401: {
-                "description": "Invalid email or password",
-                "content": {
-                    "application/json": {
-                        "example": {"detail": "Invalid email or password!"}
-                    }
-                },
-            },
-        },
-        examples=[
-            OpenApiExample(
-                "Valid Input",
-                value={
-                    "email": "john.doe@example.com",
-                    "password": "StrongPassword123!",
-                },
-                request_only=True,
-                response_only=False,
-            ),
-        ],
-    )
     def post(self, request):
         try:
             user = User.objects.get(email=request.data["email"])
@@ -403,35 +320,23 @@ class Logout(APIView):
     responses={
         200: {
             "description": "Logout successful",
-            "content": {
-                "application/json": {
-                    "example": {"detail": "Logout successful"}
-                }
-            }
+            "content": {"application/json": {"example": {"detail": "Logout successful"}}},
         },
         400: {
             "description": "Bad Request. Refresh token is required.",
-            "content": {
-                "application/json": {
-                    "example": {"detail": "Refresh token is required"}
-                }
-            }
+            "content": {"application/json": {"example": {"detail": "Refresh token is required"}}},
         },
         403: {
             "description": "Forbidden. An error occurred while logging out.",
             "content": {
-                "application/json": {
-                    "example": {"detail": "An error occurred while logging out."}
-                }
-            }
+                "application/json": {"example": {"detail": "An error occurred while logging out."}}
+            },
         },
         500: {
             "description": "Internal Server Error. An error occurred while logging out.",
             "content": {
-                "application/json": {
-                    "example": {"detail": "An error occurred while logging out."}
-                }
-            }
+                "application/json": {"example": {"detail": "An error occurred while logging out."}}
+            },
         },
     },
     examples=[
@@ -900,57 +805,6 @@ class JWTGoogleLogin(APIView):
     permission_classes = [AllowAny]
 
     @extend_schema(
-        operation_id="jwt_google_login",
-        summary="Login with Google using JWT",
-        description="Allows a user to log in using Google OAuth token and returns JWT tokens.",
-        request=GoogleLoginRequestSerializer,
-        responses={
-            200: {
-                "description": "Login successful",
-                "content": {
-                    "application/json": {
-                        "example": {
-                            "access": "abc123def456ghi789",
-                            "refresh": "abc123def456ghi789",
-                            "user": "user-uuid-string",
-                            "instructor": "instructor-uuid-string",
-                        }
-                    }
-                },
-            },
-            400: {
-                "description": "Bad Request. Token not provided or invalid.",
-                "content": {
-                    "application/json": {
-                        "example": {"message": "Token not provided"}
-                    }
-                },
-            },
-            403: {
-                "description": "Forbidden. Account does not exist.",
-                "content": {
-                    "application/json": {
-                        "example": {"message": "Account does not exist. Please sign up first."}
-                    }
-                },
-            },
-            500: {
-                "description": "Internal Server Error. An error occurred during login.",
-                "content": {
-                    "application/json": {
-                        "example": {"message": "Google login failed."}
-                    }
-                },
-            },
-        },
-        examples=[
-            OpenApiExample(
-                "Valid Input",
-                value={"token": "valid-google-oauth-token"},
-                request_only=True,
-                response_only=False,
-            ),
-        ],
         tags=["Authentication Endpoint"],
     )
     def post(self, request):

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -146,9 +146,64 @@ class SignUpInstructor(APIView):
                 )
 
 
-@extend_schema(tags=["Authentication Endpoint"])
+@extend_schema(
+    operation_id="sign_up_instructor",
+    summary="Sign up as an Instructor",
+    description="Allows a new user to sign up as an instructor by providing first name, last name (optional), email, and password. Returns JWT tokens upon successful registration.",
+    request=SignUpInstructorSerializer,
+    responses={
+        201: {
+            "description": "Instructor created successfully.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "access": "jwt_access_token",
+                        "refresh": "jwt_refresh_token",
+                        "user": "user-uuid-string",
+                        "instructor": "instructor-uuid-string",
+                    }
+                }
+            },
+        },
+        400: {
+            "description": "Bad Request. Input data is invalid.",
+            "content": {
+                "application/json": {
+                    "example": {"message": "A user with this email already exists."}
+                }
+            },
+        },
+        403: {
+            "description": "Forbidden. An error occurred while signing up.",
+            "content": {
+                "application/json": {"example": {"message": "An error occurred while signing up."}}
+            },
+        },
+        500: {
+            "description": "Internal Server Error. An error occurred while signing up.",
+            "content": {
+                "application/json": {"example": {"message": "An error occurred while signing up."}}
+            },
+        },
+    },
+    examples=[
+        OpenApiExample(
+            "Valid Input",
+            value={
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "john.doe@example.com",
+                "password": "StrongPassword123!",
+            },
+            request_only=True,
+            response_only=False,
+        ),
+    ],
+    tags=["Authentication Endpoint"],
+)
 class JWTSignUpInstructor(APIView):
     permission_classes = [AllowAny]
+    serializer_class = SignUpInstructorSerializer
 
     def post(self, request):
         serializer = SignUpInstructorSerializer(data=request.data)

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -315,6 +315,46 @@ class JWTLoginView(APIView):
     serializer_class = LoginSerializer
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        operation_id="jwt_login",
+        summary="Login with JWT",
+        description="Allows a user to log in using email and password, and returns JWT tokens.",
+        request=LoginSerializer,
+        responses={
+            200: {
+                "description": "Login successful",
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "access": "abc123def456ghi789",
+                            "refresh": "abc123def456ghi789",
+                            "user": "user-uuid-string",
+                            "instructor": "instructor-uuid-string",
+                        }
+                    }
+                },
+            },
+            401: {
+                "description": "Invalid email or password",
+                "content": {
+                    "application/json": {
+                        "example": {"detail": "Invalid email or password!"}
+                    }
+                },
+            },
+        },
+        examples=[
+            OpenApiExample(
+                "Valid Input",
+                value={
+                    "email": "john.doe@example.com",
+                    "password": "StrongPassword123!",
+                },
+                request_only=True,
+                response_only=False,
+            ),
+        ],
+    )
     def post(self, request):
         try:
             user = User.objects.get(email=request.data["email"])

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -860,10 +860,7 @@ class JWTGoogleLogin(APIView):
     permission_classes = [AllowAny]
     serializer_class = GoogleLoginRequestSerializer
 
-    @extend_schema(
-        tags=["Authentication Endpoint"],
-        request=GoogleLoginRequestSerializer
-    )
+    @extend_schema(tags=["Authentication Endpoint"], request=GoogleLoginRequestSerializer)
     def post(self, request):
         token = request.data.get("token")
 

--- a/api/views/user_views.py
+++ b/api/views/user_views.py
@@ -395,7 +395,55 @@ class Logout(APIView):
         return JsonResponse({"message": "User logged out successfully"}, status=status.HTTP_200_OK)
 
 
-@extend_schema(tags=["Authentication Endpoint"])
+@extend_schema(
+    operation_id="jwt_logout",
+    summary="Logout with JWT",
+    description="Allows a user to log out using a refresh token, and blacklists the token.",
+    request=LogoutSerializer,
+    responses={
+        200: {
+            "description": "Logout successful",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Logout successful"}
+                }
+            }
+        },
+        400: {
+            "description": "Bad Request. Refresh token is required.",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Refresh token is required"}
+                }
+            }
+        },
+        403: {
+            "description": "Forbidden. An error occurred while logging out.",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "An error occurred while logging out."}
+                }
+            }
+        },
+        500: {
+            "description": "Internal Server Error. An error occurred while logging out.",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "An error occurred while logging out."}
+                }
+            }
+        },
+    },
+    examples=[
+        OpenApiExample(
+            "Valid Input",
+            value={"refresh": "abc123def456ghi789"},
+            request_only=True,
+            response_only=False,
+        ),
+    ],
+    tags=["Authentication Endpoint"],
+)
 class JWTLogoutView(APIView):
     serializer_class = LogoutSerializer
     permission_classes = [IsAuthenticated]

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -49,6 +49,7 @@ urlpatterns = [
         name="user-response-detail",
     ),
     path("sign-up-instructor/", SignUpInstructor.as_view(), name="sign-up-instructor"),
+    path("jwt-sign-up-instructor/", JWTSignUpInstructor.as_view(), name="jwt-sign-up-instructor"),
     # path('sign-up-student/', SignUpStudent.as_view()),
     path("login/", Login.as_view(), name="login"),
     path("logout/", Logout.as_view(), name="logout"),


### PR DESCRIPTION
KAN-257
This pull request introduces a new JWT-based sign-up endpoint for instructors, along with test cases to ensure the functionality works as expected. Below are the key changes made:

- **New JWT Sign-Up Endpoint**:  
  - Created a new view `JWTSignUpInstructor` which allows users to sign up as instructors using JWT authentication.
  - The endpoint accepts the following fields: `first_name`, `last_name`, `email`, and `password`.
  - Returns a 201 status code upon successful sign-up, along with JWT tokens and user details.
  - Validates input data, returning relevant error messages for invalid inputs or missing required fields.

- **Test Cases for JWT Sign-Up**:  
  - Added comprehensive tests in `JWTSignUpInstructorTests` covering the following scenarios:
    - **Successful Sign-Up**: Tests that a user can sign up successfully with valid data and checks if an email is sent.
    - **Invalid Email Format**: Tests for proper error response when an invalid email format is provided.
    - **Missing Required Fields**: Tests for error response when required fields are not provided.
    - **Blank Last Name**: Tests that a blank last name is accepted and stored as an empty string.

- **Error Handling Enhancements**:  
  - Updated the `mailInstructor` function to log errors using a logger instead of printing, enhancing the error handling mechanism.

- **API Documentation**:  
  - Updated documentation for the new endpoint using `extend_schema` to provide clear descriptions, request body structure, and response examples for OpenAPI documentation.

- **URL Configuration**:  
  - Added a route in `urls.py` to route requests to the new JWT sign-up endpoint.

- **Existing Code Enhancements**:  
  - Improved error statuses in existing functions to provide more accurate responses (e.g., returning 403 for forbidden actions instead of 400).