### PR TITLE
KAN-236: Add Course Summaries API Endpoint and Tests

### DIFF
--- a/api/tests/test_course.py
+++ b/api/tests/test_course.py
@@ -217,3 +217,72 @@ class InstructorCoursesTests(CourseViewsTest):
         response = tmp_client.get(self.url)
 
         self.assertEqual(response.status_code, 401)
+
+
+class CourseSummariesTests(CourseViewsTest):
+    def setUp(self):
+        super().setUp()
+        self.prim_summary_course = Course.objects.create(
+            instructor=self.instructor, title="primary course for summaries tests"
+        )
+        # Add a summary for each primary recording
+        self.prim_summaries = [
+            LectureSummary.objects.create(
+                recording=recording, course=self.prim_summary_course, published=True
+            )
+            for recording in self.prim_recordings
+        ]
+
+        self.alt_summary_course = Course.objects.create(
+            instructor=self.alt_instructor, title="alt course for summaries tests"
+        )
+
+        # Add a summary for each alternative recording
+        self.alt_summaries = [
+            LectureSummary.objects.create(
+                recording=recording, course=self.alt_summary_course, published=True
+            )
+            for recording in self.alt_recordings
+        ]
+
+        self.prim_url = reverse(
+            "get-instructor-course-summaries", kwargs={"course_id": self.prim_summary_course.id}
+        )
+        self.alt_url = reverse(
+            "get-instructor-course-summaries", kwargs={"course_id": self.alt_summary_course.id}
+        )
+
+    def test_get_summaries(self):
+        prim_response = self.prim_instructor_client.get(self.prim_url)
+        alt_response = self.alt_instructor_client.get(self.alt_url)
+        prim_data = prim_response.json()
+        alt_data = alt_response.json()
+
+        self.assertEqual(prim_response.status_code, 200)
+        self.assertEqual(alt_response.status_code, 200)
+        self.assertEqual(len(prim_data), len(self.prim_recordings))
+        self.assertEqual(len(alt_data), len(self.alt_recordings))
+
+    def test_get_summaries_sorted(self):
+        prim_response = self.prim_instructor_client.get(self.prim_url)
+        alt_response = self.alt_instructor_client.get(self.alt_url)
+        prim_data = prim_response.json()
+        alt_data = alt_response.json()
+
+        self.assertEqual(prim_data[0]["id"], self.prim_summaries[-1].id.__str__())
+        self.assertEqual(alt_data[0]["id"], self.alt_summaries[-1].id.__str__())
+
+    def test_get_courses_unauthorized(self):
+        tmp_client = APIClient()
+        prim_response = tmp_client.get(self.prim_url)
+        alt_response = tmp_client.get(self.alt_url)
+
+        self.assertEqual(prim_response.status_code, 401)
+        self.assertEqual(alt_response.status_code, 401)
+
+    def test_get_courses_forbidden(self):
+        prim_response = self.prim_instructor_client.get(self.alt_url)
+        alt_response = self.alt_instructor_client.get(self.prim_url)
+
+        self.assertEqual(prim_response.status_code, 403)
+        self.assertEqual(alt_response.status_code, 403)

--- a/api/views/course_views.py
+++ b/api/views/course_views.py
@@ -1,8 +1,12 @@
 from rest_framework.views import APIView
-from api.models import InstructorRecordings, Course
+from api.models import InstructorRecordings, Course, LectureSummary
 from rest_framework import status
 from rest_framework.response import Response
-from api.serializers import InstructorRecordingsSerializer, CourseSerializer
+from api.serializers import (
+    InstructorRecordingsSerializer,
+    CourseSerializer,
+    LectureSummarySerializer,
+)
 from drf_spectacular.utils import extend_schema, OpenApiResponse
 
 from api.permissions import AllowInstructor, IsCourseOwner
@@ -43,3 +47,23 @@ class GetCoursesByInstructor(APIView):
     def get(self, request):
         courses = Course.objects.filter(instructor=request.user.instructor).order_by("-created_at")
         return Response(CourseSerializer(courses, many=True).data, status=status.HTTP_200_OK)
+
+
+@extend_schema(tags=["Instructor Course Management"])
+class GetSummariesByCourse(APIView):
+    permission_classes = [AllowInstructor & IsCourseOwner]
+
+    @extend_schema(
+        responses={
+            200: LectureSummarySerializer(many=True),
+            400: OpenApiResponse(description="Bad Request"),
+            401: OpenApiResponse(description="Unauthorized"),
+            403: OpenApiResponse(description="Forbidden"),
+            404: OpenApiResponse(description="Course not found"),
+        }
+    )
+    def get(self, request, course_id):
+        summaries = LectureSummary.objects.filter(course=course_id).order_by("-created_at")
+        return Response(
+            LectureSummarySerializer(summaries, many=True).data, status=status.HTTP_200_OK
+        )

--- a/api/views/course_views.py
+++ b/api/views/course_views.py
@@ -63,7 +63,7 @@ class GetSummariesByCourse(APIView):
         }
     )
     def get(self, request, course_id):
-        summaries = LectureSummary.objects.filter(course=course_id).order_by("-created_at")
+        summaries = LectureSummary.objects.filter(course=course_id)
         return Response(
             LectureSummarySerializer(summaries, many=True).data, status=status.HTTP_200_OK
         )

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -217,7 +217,7 @@ urlpatterns = [
         "instructor/get-courses/", GetCoursesByInstructor.as_view(), name="get-instructor-courses"
     ),
     path(
-        "instructor/course/<uuid:course_id>/get-summaries",
+        "instructor/course/<uuid:course_id>/get-summaries/",
         GetSummariesByCourse.as_view(),
         name="get-instructor-course-summaries",
     ),

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -217,6 +217,11 @@ urlpatterns = [
         "instructor/get-courses/", GetCoursesByInstructor.as_view(), name="get-instructor-courses"
     ),
     path(
+        "instructor/course/<uuid:course_id>/get-summaries",
+        GetSummariesByCourse.as_view(),
+        name="get-instructor-course-summaries",
+    ),
+    path(
         "token/verify/",
         TokenVerificationView.as_view(),
         name="verify-token",

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -213,7 +213,9 @@ urlpatterns = [
         GetRecordingsByCourse.as_view(),
         name="get-course-recordings",
     ),
-    path("instructor/get-courses/", GetCoursesByInstructor.as_view(), name="get-instructor-courses"),
+    path(
+        "instructor/get-courses/", GetCoursesByInstructor.as_view(), name="get-instructor-courses"
+    ),
     path(
         "token/verify/",
         TokenVerificationView.as_view(),


### PR DESCRIPTION
- Introduced a new API endpoint for retrieving lecture summaries by course.
  - Implemented `GetSummariesByCourse` class-based view.
  - Allowed access only to instructors and course owners using permission classes.
  - Provided detailed OpenAPI specifications for the endpoint including responses for 200, 400, 401, 403, and 404 status codes.

- Updated models and serializers:
  - Imported `LectureSummary` model to handle course summaries.
  - Added `LectureSummarySerializer` for serializing summary data.

- Enhanced tests for course summaries:
  - Created a new test class `CourseSummariesTests` to perform tests on the new endpoint.
  - Added functionality to create test courses and lecture summaries in the `setUp` method.
  - Implemented multiple test cases including:
    - `test_get_summaries`: Validates successful retrieval of summaries for both primary and alternative courses.
    - `test_get_summaries_sorted`: Ensures that summaries are sorted correctly when retrieved.
    - `test_get_courses_unauthorized`: Checks for unauthorized access attempts.
    - `test_get_courses_forbidden`: Tests response for instructors trying to access summaries of courses they do not own.

- Updated URL configuration:
  - Added the new endpoint `/instructor/course/<uuid:course_id>/get-summaries` for accessing course summaries.