### PR TITLE
KAN-268: Enhance Quiz WebSocket Consumer with Quiz Details and User Count

### DIFF
--- a/api/consumers.py
+++ b/api/consumers.py
@@ -48,7 +48,9 @@ class QuizSessionInstructorConsumer(AsyncWebsocketConsumer):
 
     @database_sync_to_async
     def get_quiz_json(self):
-        return QuizSerializer(QuizSession.objects.get(code=self.code).quiz).data
+        data = QuizSerializer(QuizSession.objects.get(code=self.code).quiz).data
+        data["instructor_recording"] = str(data["instructor_recording"])
+        return data
 
     async def disconnect(self, close_code):
         await self.channel_layer.group_discard(self.group_name, self.channel_name)

--- a/api/consumers.py
+++ b/api/consumers.py
@@ -495,7 +495,7 @@ class StudentConsumer(AsyncWebsocketConsumer):
         return QuizSession.objects.get(code=self.code).quiz
 
     async def check_and_grant_skip_power_up(self, student_id):
-        quiz = await self.get_quiz(self.code)
+        quiz = await self.get_quiz()
         correct_responses = await self.get_correct_responses(student_id)
         student = await self.get_student(student_id)
         if quiz.skip_question:

--- a/api/consumers.py
+++ b/api/consumers.py
@@ -18,6 +18,8 @@ from api.models import (
     QuizSessionQuestion,
 )
 
+from .serializers import QuizSerializer
+
 logger = logging.getLogger(__name__)
 
 from channels.db import database_sync_to_async
@@ -31,10 +33,22 @@ class QuizSessionInstructorConsumer(AsyncWebsocketConsumer):
 
         await self.accept()
 
+        quiz_data = await self.get_quiz_json()
+
+        uc = await self.fetch_user_count()
+
+        await self.send(
+            text_data=json.dumps({"type": "quiz_details", "quiz": quiz_data, "user_count": uc})
+        )
+
     @database_sync_to_async
     def fetch_user_count(self):
         session = QuizSession.objects.get(code=self.code)
         return session.students.count()
+
+    @database_sync_to_async
+    def get_quiz_json(self):
+        return QuizSerializer(QuizSession.objects.get(code=self.code).quiz).data
 
     async def disconnect(self, close_code):
         await self.channel_layer.group_discard(self.group_name, self.channel_name)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -110,6 +110,7 @@ class QuizSerializer(serializers.ModelSerializer):
             "title",
             "start_time",
             "end_time",
+            "timer",
             "instructor_recording",
             "created_at",
             "num_questions",

--- a/api/tests/consumer_tests.py
+++ b/api/tests/consumer_tests.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import User
 from api.models import (
     Quiz,
     Instructor,
+    InstructorRecordings,
     QuizSession,
     QuizSessionStudent,
     UserResponse,
@@ -36,6 +37,13 @@ async def test_quiz():
     )
 
     # ----------------------------
+    # Create a Recording
+    # ----------------------------
+    recording = await sync_to_async(InstructorRecordings.objects.create)(
+        instructor=instructor, title="test"
+    )
+
+    # ----------------------------
     # Create a Quiz
     # ----------------------------
     quiz = await sync_to_async(Quiz.objects.create)(
@@ -43,7 +51,7 @@ async def test_quiz():
         instructor=instructor,
         timer=True,
         created_at=timezone.now(),
-        instructor_recording=None,  # Or set to an existing InstructorRecordings instance
+        instructor_recording=recording,
     )
 
     # ----------------------------


### PR DESCRIPTION
This PR implements improvements to the WebSocket consumer for quizzes by including detailed quiz information and user count when a connection is established.

### Changes Made:
- **Updated WebSocket Connect Method:**  
  - Integrated fetching of quiz details and user count into the `connect` method.  
  - Sending a JSON payload with `quiz_details`, incorporating `quiz` data and `user_count` upon connection.

- **Added Method to Retrieve Quiz JSON:**  
  - Created `get_quiz_json()` method that utilizes `QuizSerializer` to serialize quiz data from the corresponding `QuizSession`.  
  - Enhanced modularity and separation of concerns in the WebSocket consumer.

- **Modified Quiz Serializer:**  
  - Added the `timer` field to the quiz serializer to include the timer information in the serialized output.

- **Updated Test Cases:**  
  - Renamed test function from `test_instructor_end_quiz` to `test_quiz` for a more accurate representation of its purpose.  
  - Adjusted comments to clarify actions during various steps of the test flow.
  - Included assertions to verify the presence of `quiz`, `timer`, and `user_count` in the initial WebSocket response messages to ensure correctness in the updated flow.

### Notable Assertions in Tests:
  - Asserted that the received response type is `quiz_details`.
  - Confirmed that the response contains `quiz`, `timer`, and `user_count` to ensure all necessary information is transmitted on connection.