### PR TITLE
KAN-238: Implement Course Retrieval for Students

### DIFF
--- a/api/views/course_views.py
+++ b/api/views/course_views.py
@@ -2,11 +2,13 @@ from rest_framework.views import APIView
 from api.models import InstructorRecordings, Course, LectureSummary, CourseStudent
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 from api.serializers import (
     InstructorRecordingsSerializer,
     CourseSerializer,
     LectureSummarySerializer,
     CourseStudentSerializer,
+    Student,
 )
 from drf_spectacular.utils import extend_schema, OpenApiResponse
 
@@ -99,3 +101,21 @@ class GetStudentsByCourse(APIView):
         return Response(
             CourseStudentSerializer(students, many=True).data, status=status.HTTP_200_OK
         )
+
+
+@extend_schema(tags=["Student Course Management"])
+class GetCoursesByStudent(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        responses={
+            200: CourseSerializer(many=True),
+            401: OpenApiResponse(description="Unauthorized"),
+        }
+    )
+    def get(self, request):
+        student_courses = CourseStudent.objects.filter(student__user=request.user).order_by(
+            "-joined_at"
+        )
+        courses = [sc.course for sc in student_courses]
+        return Response(CourseSerializer(courses, many=True).data, status=status.HTTP_200_OK)

--- a/api/views/course_views.py
+++ b/api/views/course_views.py
@@ -8,7 +8,6 @@ from api.serializers import (
     CourseSerializer,
     LectureSummarySerializer,
     CourseStudentSerializer,
-    Student,
 )
 from drf_spectacular.utils import extend_schema, OpenApiResponse
 

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -231,6 +231,7 @@ urlpatterns = [
         GetStudentsByCourse.as_view(),
         name="get-course-students",
     ),
+    path("student/get-courses/", GetCoursesByStudent.as_view(), name="get-courses-by-student"),
     path(
         "token/verify/",
         TokenVerificationView.as_view(),


### PR DESCRIPTION
# Overview
This pull request introduces a new feature that allows students to retrieve their enrolled courses through an authenticated API endpoint.

## Changes Made:
- **View Creation:**  
  - Added a new API view `GetCoursesByStudent` to handle GET requests for fetching courses.
  - Implemented permission checks to ensure that only authenticated users can access the course data.

- **URL Routing:**  
  - Updated the URL configuration to include a new route for `GetCoursesByStudent`. 
  - The endpoint can be reached at `/student/get-courses/`.

- **Testing Enhancements:**  
  - Created a new test class `StudentCoursesTest` in `test_course.py` to validate the functionality of the new endpoint. 
  - Added multiple test cases, including:  
    - Validating successful retrieval of courses (expecting a 200 status code).  
    - Checking that the number of courses returned matches the expected count (5).  
    - Verifying the proper sorting of courses based on the join date.  
    - Testing the unauthorized access scenario to ensure it returns a 401 status code.  
    - Ensuring the response structure adheres to the expected keys for course details.

- **Response Structure Validation:**  
  - Implemented assertions in the tests to confirm the structure of the response data includes the necessary fields such as `id`, `instructor`, `title`, `description`, etc.

## Additional Notes:
- All new tests have been implemented to maintain code coverage and ensure the functionality is robust.
- The addition of the `IsAuthenticated` permission class is crucial for securing student data and ensuring that only logged-in users can access their courses.