### PR TITLE
KAN-267: Enhance Course Summaries Retrieval for Students

### DIFF
--- a/api/tests/test_course.py
+++ b/api/tests/test_course.py
@@ -571,11 +571,17 @@ class FetchPublishedCoursesTest(CourseViewsTest):
             recording=self.recording,
             course=self.course,
             published=True,
+            summary = "Summary 1", 
         )
 
         self.published_summary_2 = LectureSummary.objects.create(
-            recording=self.recording, course=self.course, published=True
+            recording=self.recording, 
+            course=self.course, 
+            published=True, 
+            summary = "Summary 2",
         )
+        self.published_summary_2.created_at = self.published_summary_1.created_at + timedelta(days=1)
+        self.published_summary_2.save()
 
         self.unpublished_summary = LectureSummary.objects.create(
             recording=self.recording, course=self.course, published=False
@@ -586,6 +592,8 @@ class FetchPublishedCoursesTest(CourseViewsTest):
         summaries = response.json()
         self.assertEqual(len(summaries), 2)
         self.assertEqual(response.status_code, 200)
+        print(f"\nReponse: {response.json()}\n")
+        self.assertEqual(response.data[0]["summary"], "Summary 2")
 
     def test_get_summaries_unauthorized(self):
         response = self.client_student_2.get(self.url)

--- a/api/tests/test_course.py
+++ b/api/tests/test_course.py
@@ -571,16 +571,18 @@ class FetchPublishedCoursesTest(CourseViewsTest):
             recording=self.recording,
             course=self.course,
             published=True,
-            summary = "Summary 1", 
+            summary="Summary 1",
         )
 
         self.published_summary_2 = LectureSummary.objects.create(
-            recording=self.recording, 
-            course=self.course, 
-            published=True, 
-            summary = "Summary 2",
+            recording=self.recording,
+            course=self.course,
+            published=True,
+            summary="Summary 2",
         )
-        self.published_summary_2.created_at = self.published_summary_1.created_at + timedelta(days=1)
+        self.published_summary_2.created_at = self.published_summary_1.created_at + timedelta(
+            days=1
+        )
         self.published_summary_2.save()
 
         self.unpublished_summary = LectureSummary.objects.create(

--- a/api/tests/test_course.py
+++ b/api/tests/test_course.py
@@ -553,3 +553,47 @@ class StudentCoursesTest(CourseViewsTest):
         }
         for course in courses:
             self.assertTrue(expected_keys.issubset(course.keys()))
+
+
+class FetchPublishedCoursesTest(CourseViewsTest):
+    def setUp(self):
+        super().setUp()
+        self.unenrolled_course = Course.objects.create(
+            instructor=self.instructor, title="Unenrolled Course"
+        )
+        self.url = reverse("get-published-summaries", kwargs={"course_id": self.course.id})
+
+        self.recording = InstructorRecordings.objects.create(
+            instructor=self.instructor, title="Main Recording", course=self.course
+        )
+
+        self.published_summary_1 = LectureSummary.objects.create(
+            recording=self.recording,
+            course=self.course,
+            published=True,
+        )
+
+        self.published_summary_2 = LectureSummary.objects.create(
+            recording=self.recording, course=self.course, published=True
+        )
+
+        self.unpublished_summary = LectureSummary.objects.create(
+            recording=self.recording, course=self.course, published=False
+        )
+
+    def test_get_summaries(self):
+        response = self.client_student_1.get(self.url)
+        summaries = response.json()
+        self.assertEqual(len(summaries), 2)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_summaries_unauthorized(self):
+        response = self.client_student_2.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_summaries_invalid_course_id(self):
+        invalid_url = reverse(
+            "get-published-summaries", kwargs={"course_id": "c56a4180-65aa-42ec-a945-5fd21dec0538"}
+        )
+        response = self.client_student_1.get(invalid_url)
+        self.assertEqual(response.status_code, 404)

--- a/api/views/course_views.py
+++ b/api/views/course_views.py
@@ -11,7 +11,7 @@ from api.serializers import (
 )
 from drf_spectacular.utils import extend_schema, OpenApiResponse
 
-from api.permissions import AllowInstructor, IsCourseOwner
+from api.permissions import AllowInstructor, IsCourseOwner, IsEnrolledInCourse
 
 
 @extend_schema(tags=["Instructor Course Management"])
@@ -118,3 +118,17 @@ class GetCoursesByStudent(APIView):
         )
         courses = [sc.course for sc in student_courses]
         return Response(CourseSerializer(courses, many=True).data, status=status.HTTP_200_OK)
+
+
+@extend_schema(tags=["Summaries"])
+class FetchPublishedSummariesView(APIView):
+    permission_classes = [IsEnrolledInCourse]
+
+    @extend_schema(
+        description="Endpoint for students to get published summaries given course id that they are in"
+    )
+    def get(self, request, course_id):
+        summaries = LectureSummary.objects.filter(course=course_id, published=True)
+        return Response(
+            LectureSummarySerializer(summaries, many=True).data, status=status.HTTP_200_OK
+        )

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -219,7 +219,9 @@ urlpatterns = [
         name="get-course-recordings",
     ),
     path(
-        "instructor/get-courses/", GetCoursesByInstructor.as_view(), name="get-instructor-courses"
+        "instructor/get-courses/",
+        GetCoursesByInstructor.as_view(),
+        name="get-instructor-courses",
     ),
     path(
         "instructor/course/<uuid:course_id>/get-summaries/",
@@ -232,6 +234,11 @@ urlpatterns = [
         name="get-course-students",
     ),
     path("student/get-courses/", GetCoursesByStudent.as_view(), name="get-courses-by-student"),
+    path(
+        "student/course/<course_id>/get-summaries/",
+        view=FetchPublishedSummariesView.as_view(),
+        name="get-published-summaries",
+    ),
     path(
         "token/verify/",
         TokenVerificationView.as_view(),


### PR DESCRIPTION
This PR introduces a new feature allowing students to fetch published summaries for courses they are enrolled in. The updates made include test cases, view logic, and the necessary URL routing adjustments. Below are the detailed changes:

### Overview of Changes:
- **New View Class Implementation**:
  - Added the `FetchPublishedSummariesView` to handle requests for published lecture summaries.
  - Utilizes the `IsEnrolledInCourse` permission class to ensure only enrolled students can access summaries.

- **Updated URL Routing**:
  - Added a new URL endpoint for fetching published summaries: `student/course/<course_id>/get-summaries/`.

- **Added Unit Tests**:
  - Introduced `FetchPublishedCoursesTest` class which encompasses several test cases to ensure proper functionality:
    - **test_get_summaries**: Confirms that enrolled students can retrieve the correct number of published summaries (2).
    - **test_get_summaries_unauthorized**: Verifies that unauthorized users (unenrolled students) receive a 403 Forbidden response.
    - **test_get_summaries_invalid_course_id**: Checks the response for an invalid course ID, expecting a 404 Not Found.

- **Modified Permissive Imports**:
  - Included the new permission `IsEnrolledInCourse` in `course_views.py` to regulate access to the summaries.

- **Serializer Usage**:
  - Updated the serialization of summaries in `FetchPublishedSummariesView` to ensure consistent response formats.

### Testing:
- All new tests pass successfully, confirming that the permissions and data retrieval are functioning as expected.