### PR TITLE
Remove redundant comment in QuestionView get method

### DIFF
--- a/api/views/question_views.py
+++ b/api/views/question_views.py
@@ -68,7 +68,6 @@ class CreateMultipleQuestionsView(APIView):
 class QuestionView(APIView):
     permission_classes = [IsQuestionOwner]
 
-    # Get method to question by id
     def get(self, request, question_id):
         question = get_object_or_404(QuestionMultipleChoice, id=question_id)
         serializer = QuestionMultipleChoiceSerializer(question)


### PR DESCRIPTION
The removed comment was unnecessary as the function name and code are self-explanatory. This improves code readability and eliminates clutter.