### PR TITLE
KAN-291: Enhance Recording Management: Update Functionality and Serializer Improvements

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -74,10 +74,35 @@ class QuizSessionStudentSerializer(serializers.ModelSerializer):
 class InstructorRecordingsSerializer(serializers.ModelSerializer):
     class Meta:
         model = InstructorRecordings
-        fields = ["id", "s3_path", "uploaded_at", "instructor", "transcript", "title"]
+        fields = [
+            "id",
+            "s3_path",
+            "uploaded_at",
+            "instructor",
+            "transcript",
+            "title",
+            "duration",
+            "course",
+            "published",
+        ]
         read_only_fields = ["id", "uploaded_at", "transcript"]
 
         instructor = serializers.PrimaryKeyRelatedField(read_only=True)
+
+
+class RecordingUpdateSerializer(serializers.Serializer):
+    title = serializers.CharField()
+    duration = serializers.IntegerField()
+    course = serializers.UUIDField()
+    published = serializers.BooleanField()
+
+    def update(self, instance, validated_data):
+        instance.title = validated_data.get("title", instance.title)
+        instance.duration = validated_data.get("duration", instance.duration)
+        instance.course = validated_data.get("course", instance.course)
+        instance.published = validated_data.get("published", instance.published)
+        instance.save()
+        return instance
 
 
 class UpdateTranscriptSerializer(serializers.Serializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -89,7 +89,8 @@ class RecordingUpdateSerializer(serializers.Serializer):
     def update(self, instance, validated_data):
         instance.title = validated_data.get("title", instance.title)
         instance.duration = validated_data.get("duration", instance.duration)
-        instance.course = validated_data.get("course", instance.course)
+        if validated_data.get("course"):
+            instance.course = Course.objects.get(id=validated_data["course"])
         instance.published = validated_data.get("published", instance.published)
         instance.save()
         return instance

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -260,4 +260,9 @@ urlpatterns = [
     path(
         "sessions/<int:session_id>/update-scores/", UpdateScoresView.as_view(), name="update-scores"
     ),
+    path(
+        "recordings/<uuid:recording_id>/update/",
+        UpdateRecordingView.as_view(),
+        name="update-recording",
+    ),
 ]

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -261,11 +261,13 @@ urlpatterns = [
         "sessions/<int:session_id>/update-scores/", UpdateScoresView.as_view(), name="update-scores"
     ),
     path(
-        "recordings/<uuid:recording_id>/update/", UpdateRecordingView.as_view(), name="update-recording"
+        "recordings/<uuid:recording_id>/update/",
+        UpdateRecordingView.as_view(),
+        name="update-recording",
     ),
     path(
         "recordings/<uuid:recording_id>/move-recording-to-course/",
         UpdateRecordingCourseView.as_view(),
-        name="update-recording-course"
-    )
+        name="update-recording-course",
+    ),
 ]


### PR DESCRIPTION
KAN-291
This pull request includes several changes to the `api` and `hice_backend` modules, primarily focusing on adding new functionality for updating recording details. The most important changes include updates to the serializers, views, and URL configurations.

### Serializer Updates:
* [`api/serializers.py`](diffhunk://#diff-1acc662da69290fd8ce4137ddec9d9cc131df53d76d6d107a13c95550781e81eL77-R107): Added new fields `duration`, `course`, and `published` to `InstructorRecordingsSerializer`. Introduced `RecordingUpdateSerializer` for handling updates to recording details.

### View Updates:
* [`api/views/recordings_views.py`](diffhunk://#diff-67c71ad663c7d11493c48b1c1196e9feb56db5a5c0490f66ff070045e65c0453L1-R33): Added imports for new dependencies and logging. Introduced `UpdateRecordingView` class with a `patch` method to handle updating existing recordings using `RecordingUpdateSerializer`. [[1]](diffhunk://#diff-67c71ad663c7d11493c48b1c1196e9feb56db5a5c0490f66ff070045e65c0453L1-R33) [[2]](diffhunk://#diff-67c71ad663c7d11493c48b1c1196e9feb56db5a5c0490f66ff070045e65c0453R245-R281)

### URL Configuration:
* [`hice_backend/urls.py`](diffhunk://#diff-9f768afe2375c04fde938e93a4acde064cc9876c5e5fa3140abeab4b8be387fbR263-R267): Added a new URL pattern for `UpdateRecordingView` to handle update requests for recordings.