### PR TITLE
[KAN-317] Enhance Course Recordings Response with Transcript Status

### DIFF
--- a/api/views/course_views.py
+++ b/api/views/course_views.py
@@ -1,4 +1,3 @@
-from django.http import JsonResponse
 from rest_framework.views import APIView
 from api.models import InstructorRecordings, Course, LectureSummary, CourseStudent
 from rest_framework import status

--- a/api/views/course_views.py
+++ b/api/views/course_views.py
@@ -1,3 +1,4 @@
+from django.http import JsonResponse
 from rest_framework.views import APIView
 from api.models import InstructorRecordings, Course, LectureSummary, CourseStudent
 from rest_framework import status
@@ -32,9 +33,11 @@ class GetRecordingsByCourse(APIView):
         recordings = InstructorRecordings.objects.filter(
             instructor=request.user.instructor, course=course_id
         ).order_by("-uploaded_at")
-        return Response(
-            InstructorRecordingsSerializer(recordings, many=True).data, status=status.HTTP_200_OK
-        )
+        data = InstructorRecordingsSerializer(recordings, many=True).data
+
+        for recording in data:
+            recording["transcript"] = "completed" if recording.get("transcript") else "pending"
+        return Response(data, status=status.HTTP_200_OK)
 
 
 @extend_schema(tags=["Instructor Course Management"])


### PR DESCRIPTION
This PR introduces enhancements to the API endpoint for retrieving instructor recordings associated with a specific course. The changes include:

- **Imported `JsonResponse`**: Added `JsonResponse` from `django.http` for potential future use (not utilized in this PR).
- **Transcript Status Update**: For each recording returned in the response:
  - Introduced a check for the presence of the `transcript` key.
  - Updated the `transcript` field in the response data:
    - If `transcript` exists, set the value to "completed".
    - If `transcript` does not exist, set the value to "pending".
- **Code Refactoring**: Separated the serialization logic from the response return statement to improve readability and maintainability.

These changes provide clearer information to front-end developers and clients about the state of the transcripts associated with each recording.