### PR TITLE
KAN-314: Add Download Recording Functionality

### DIFF
--- a/api/views/recordings_views.py
+++ b/api/views/recordings_views.py
@@ -309,7 +309,7 @@ class UpdateRecordingCourseView(APIView):
 
 
 @extend_schema(tags=["Recordings"])
-class DownloadRecordingView:
+class DownloadRecordingView(APIView):
     permission_classes = [IsRecordingOwner]
 
     @extend_schema(

--- a/api/views/recordings_views.py
+++ b/api/views/recordings_views.py
@@ -14,6 +14,7 @@ from drf_spectacular.utils import (
 from rest_framework import serializers, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from django.http import FileResponse
 from rest_framework.views import APIView
 
 from api.models import Instructor, InstructorRecordings, LectureSummary, Quiz
@@ -305,3 +306,40 @@ class UpdateRecordingCourseView(APIView):
             response_serializer = InstructorRecordingsSerializer(updated_recording)
             return Response(response_serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
+
+@extend_schema(tags=["Recordings"])
+class DownloadRecordingView:
+    permission_classes = [IsRecordingOwner]
+
+    @extend_schema(
+        description="Endpoint to get a recording file",
+        responses={
+            200: "Recording Retrieved",
+            400: "Bad Request",
+            401: "Unauthorized",
+            404: "Not Found",
+        },
+    )
+    def get(self, request, recording_id):
+        recording = get_object_or_404(InstructorRecordings, id=recording_id)
+
+        s3_client = boto3.client(
+            's3',
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+            region_name=settings.AWS_S3_REGION_NAME,
+        )
+
+        try:
+            # Get file object from S3
+            file_obj = s3_client.get_object(Bucket="NEED TO CHANGE THIS TO BUCKET NAME", Key=recording.s3_path)
+
+
+            response = FileResponse(file_obj['Body'], content_type=file_obj['ContentType'])
+            response['Content-Disposition'] = f'attachment; filename="{recording.s3_path.split("/")[-1]}"'
+            return response
+
+        except Exception:
+            return Response({"error": "Exception Occured"}, status=403)
+    

--- a/api/views/recordings_views.py
+++ b/api/views/recordings_views.py
@@ -306,7 +306,7 @@ class UpdateRecordingCourseView(APIView):
             response_serializer = InstructorRecordingsSerializer(updated_recording)
             return Response(response_serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-    
+
 
 @extend_schema(tags=["Recordings"])
 class DownloadRecordingView:
@@ -325,7 +325,7 @@ class DownloadRecordingView:
         recording = get_object_or_404(InstructorRecordings, id=recording_id)
 
         s3_client = boto3.client(
-            's3',
+            "s3",
             aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
             region_name=settings.AWS_S3_REGION_NAME,
@@ -333,13 +333,15 @@ class DownloadRecordingView:
 
         try:
             # Get file object from S3
-            file_obj = s3_client.get_object(Bucket="NEED TO CHANGE THIS TO BUCKET NAME", Key=recording.s3_path)
+            file_obj = s3_client.get_object(
+                Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=recording.s3_path
+            )
 
-
-            response = FileResponse(file_obj['Body'], content_type=file_obj['ContentType'])
-            response['Content-Disposition'] = f'attachment; filename="{recording.s3_path.split("/")[-1]}"'
+            response = FileResponse(file_obj["Body"], content_type=file_obj["ContentType"])
+            response["Content-Disposition"] = (
+                f'attachment; filename="{recording.s3_path.split("/")[-1]}"'
+            )
             return response
 
         except Exception:
             return Response({"error": "Exception Occured"}, status=403)
-    

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -170,7 +170,7 @@ urlpatterns = [
         name="update-recording-duration",
     ),
     path(
-        "recordings/<uuid:recording_id/download-recording/",
+        "recordings/<uuid:recording_id>/download-recording/",
         DownloadRecordingView.as_view(),
         name="download-recording",
     ),

--- a/hice_backend/urls.py
+++ b/hice_backend/urls.py
@@ -170,6 +170,11 @@ urlpatterns = [
         name="update-recording-duration",
     ),
     path(
+        "recordings/<uuid:recording_id/download-recording/",
+        DownloadRecordingView.as_view(),
+        name="download-recording",
+    ),
+    path(
         "recordings/",
         RecordingsView.as_view(),
         name="instructor-recording",


### PR DESCRIPTION
This pull request introduces a new endpoint for downloading recordings, enhancing the API's capabilities by allowing users to retrieve recording files directly. Below are the key changes made:

### Changes Made:
- **New View Created**: `DownloadRecordingView`
  - Implemented a new API view for downloading specific recording files.
  - Protected the view with the `IsRecordingOwner` permission to ensure that only the owner of the recording can access it.

- **GET Method Implementation**:
  - Added a `get` method to fetch a recording file using the provided recording ID.
  - Utilizes `get_object_or_404` to ensure that an appropriate response is given if the recording does not exist (404 status).

- **S3 Integration**:
  - Utilized `boto3` to connect to AWS S3 and retrieve the file.
  - Configured S3 client with credentials and region from settings.
  - Added error handling to gracefully manage exceptions that may occur when accessing S3.

- **File Response**:
  - Returned the file as a `FileResponse`, ensuring the correct content type is set to facilitate proper delivery of the file.
  - Set the `Content-Disposition` header to prompt file download with the appropriate filename.

- **New URL Path**:
  - Added a new URL route in `hice_backend/urls.py` to allow access to the download endpoint, ensuring the endpoint can be reached via `GET` request at `/recordings/<uuid:recording_id>/download-recording/`

### Response Codes Implemented:
- **200**: Successful recording retrieval.
- **400**: Bad request for invalid input.
- **401**: Unauthorized access if the user is not allowed to access the recording.
- **404**: Not found if the recording does not exist.
- **403**: Forbidden response on generic S3 access exceptions.

### Summary:
This update significantly enhances the user experience by adding the ability to download recordings directly, with proper permission controls and error handling in place.